### PR TITLE
chore: update e2e tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
       - run: yarn run lint
 
   test:
+    env:
+      CI: true
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,6 +27,7 @@ jobs:
           - 14.x
           - 16.x
           - 18.x
+          - 20.x
     steps:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   ],
   "devDependencies": {
     "@comunica/actor-http-proxy": "^2.6.9",
-    "@comunica/query-sparql": "^2.6.9",
+    "@comunica/query-sparql": "^2.9.0",
     "@types/jest": "^29.0.0",
     "coveralls": "^3.0.0",
     "jest": "^29.0.0",

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -13,10 +13,13 @@ if (!fs.existsSync(path.join(__dirname, 'cache')))
 
 describe('e2e tests on the test suite runner', () => {
   const parsingSpecs = [
-    "http://w3c.github.io/rdf-tests/ntriples/manifest.ttl",
-    "http://w3c.github.io/rdf-tests/nquads/manifest.ttl",
-    "http://w3c.github.io/rdf-tests/turtle/manifest.ttl",
-    "http://w3c.github.io/rdf-tests/trig/manifest.ttl",
+    // TODO: Use this rather than explicitly listing the included manifests
+    // this requires supporting the RDF-MT and RDF/XML test suite
+    // "https://w3c.github.io/rdf-tests/rdf/rdf11/manifest.ttl",
+    "https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-n-triples/manifest.ttl",
+    "https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-n-quads/manifest.ttl",
+    "https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-turtle/manifest.ttl",
+    "https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-trig/manifest.ttl",
     "https://w3c.github.io/json-ld-api/tests/toRdf-manifest.jsonld",
     "https://w3c.github.io/json-ld-streaming/tests/stream-toRdf-manifest.jsonld",
 
@@ -106,7 +109,7 @@ describe('e2e tests on the test suite runner', () => {
 
       it(`should run correctly on [${spec}]`, async () => {
         config.specification = spec
-        const result = await runner.runManifest('http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl', queryEngine(new QueryEngine()), config);
+        let result = await runner.runManifest('http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl', queryEngine(new QueryEngine()), config);
 
         // Run assertions
         expect(console.log).not.toHaveBeenCalled();
@@ -126,7 +129,9 @@ describe('e2e tests on the test suite runner', () => {
         // Unsupported test can be skipped
         if (!spec.includes('tsv') && !spec.includes('rdf-update') && !spec.includes('service-description') && !spec.includes('protocol'))
           expect(skipped).toEqual(0);
-
+        
+        // Comunica does not support ZeroOrOne paths with a variable at the start and end
+        result = result.filter(r => r.test.uri !== 'http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path');
         expect(result.every(r => r.ok || r.skipped)).toEqual(true);
 
       }, 190_000);

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -11,6 +11,10 @@ import * as fs from 'fs';
 if (!fs.existsSync(path.join(__dirname, 'cache')))
   fs.mkdirSync(path.join(__dirname, 'cache'))
 
+if (process.env.CI) {
+  jest.retryTimes(3);
+}
+
 describe('e2e tests on the test suite runner', () => {
   const parsingSpecs = [
     // TODO: Use this rather than explicitly listing the included manifests

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -113,7 +113,7 @@ describe('e2e tests on the test suite runner', () => {
 
       it(`should run correctly on [${spec}]`, async () => {
         config.specification = spec
-        let result = await runner.runManifest('http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl', queryEngine(new QueryEngine()), config);
+        const result = await runner.runManifest('http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl', queryEngine(new QueryEngine()), config);
 
         // Run assertions
         expect(console.log).not.toHaveBeenCalled();

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -129,9 +129,7 @@ describe('e2e tests on the test suite runner', () => {
         // Unsupported test can be skipped
         if (!spec.includes('tsv') && !spec.includes('rdf-update') && !spec.includes('service-description') && !spec.includes('protocol'))
           expect(skipped).toEqual(0);
-        
-        // Comunica does not support ZeroOrOne paths with a variable at the start and end
-        result = result.filter(r => r.test.uri !== 'http://www.w3.org/2009/sparql/docs/tests/data-sparql11/property-path/manifest#values_and_path');
+
         expect(result.every(r => r.ok || r.skipped)).toEqual(true);
 
       }, 190_000);

--- a/yarn.lock
+++ b/yarn.lock
@@ -311,6 +311,14 @@
     "@comunica/core" "^2.6.8"
     "@comunica/types" "^2.6.8"
 
+"@comunica/actor-abstract-mediatyped@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-2.8.2.tgz#18265089afb5c0da7253a3476fd59d3193d98382"
+  integrity sha512-WXkvFfDjWSJw1KRknNtqOIC9cLc9Jg24ItHfpqQ9p4slq/448j2kOZEaxi0PhfDbw2wfUuF92nyo7tuajzSnSg==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
 "@comunica/actor-abstract-parse@^2.6.8":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.6.8.tgz#b0771cdee900ad4c8d9d9db693fae3138552fd5f"
@@ -319,73 +327,81 @@
     "@comunica/core" "^2.6.8"
     readable-stream "^4.2.0"
 
-"@comunica/actor-abstract-path@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-2.6.8.tgz#ec1e51b4d732a77db43e08a438393cc0dc30e69f"
-  integrity sha512-qj8veS8O6xv0Q1Oq8Z7hkmdkEvjAJ8WWSUNc0HbrmJEZM2DfwycbyT2/p6oqfvy0S004bEWDFjTb24Jd6M4Rtw==
+"@comunica/actor-abstract-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.8.2.tgz#d018d22c38586661bb2375149752d67cb6e38187"
+  integrity sha512-ruFphf3Xil+oZGUJw2N0UF/E/Jo7v+mCER8RUiTJi/94etZSa7jEZ9wCZQNfZmmQy8X4cTJkls4ItSxyJ0yu2w==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    readable-stream "^4.2.0"
+
+"@comunica/actor-abstract-path@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-2.9.0.tgz#e4ada3f0d6c6773c3eee09d43f96a99198c5703a"
+  integrity sha512-47p1k4joxLhQcj05qVeFOJefqDZNI6V12Ihi80ZLC6Q/6JJql3lhuNHxoa4ypSivHQgMh2HnQI5gaQQdUS4EzQ==
+  dependencies:
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-context-preprocess-source-to-destination@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.6.8.tgz#d80c99562b1e6dea03adcd682f0f2cbb7ee3de17"
-  integrity sha512-k4ciLj+LyVTrwJ+AKYflbRcAHeg9wU/xz+TlUwH59l04MBzFdI/EFpk+0z4J9RmkqI4+FyEFYukKk5eKS8vcSQ==
+"@comunica/actor-context-preprocess-source-to-destination@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-2.8.2.tgz#bf93e6062963369e569135c50c61fd7140fc17a4"
+  integrity sha512-m/VAc8dXNuz2thZ7Ey7lnPlHfY5y68b6YNdTsGLX8XRJGT7v8xb8gL7p46KKSj6N+ywQg3pdExADUlmQFJGCuw==
   dependencies:
-    "@comunica/bus-context-preprocess" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-context-preprocess" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/actor-dereference-fallback@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.6.8.tgz#a353710df192d80a65a1fae62f18b3ac52c1d7b7"
-  integrity sha512-Yp7dnANzowvdqpEP7pe1mHzb+rllxKu2DOHV4VZwVm5+Yr4kEObfL0oT0Gc5vqBsfIw8cyaCHgt23IJO8aoQYA==
+"@comunica/actor-dereference-fallback@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-2.8.2.tgz#8c128db4722b39918fe90dfad6d13b1a40bc9ec5"
+  integrity sha512-XDEUN54hyX/phxzJQFbkemoO92CIwa30YHys6bQV1mtfy8oINqfpabFXNr9VSsMO3CpQE5FsfJfFWUD8vdcSVw==
   dependencies:
-    "@comunica/bus-dereference" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-dereference-http@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-2.6.9.tgz#806092c13b1bb635e14cc5530220df23f386b6a7"
-  integrity sha512-K7GWIR0SkYaH+lQO8pWoCxlQuQU67Y/2j9jlinqWEMbbVmHvvKt455RBxFWs8gfHRzXon7MzCqjAhC+BB3VGow==
+"@comunica/actor-dereference-http@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-2.8.2.tgz#90bea997db993d1223170b82043bef85d12add6f"
+  integrity sha512-3yaGR+3o+t1avUYmgeZzvYqQvQ1fMGn2Ji0FrYuEwbx9Wty0kCr7jRjDYB4VyagwPx6lzQy0RVoNb6LbUNSiXA==
   dependencies:
-    "@comunica/bus-dereference" "^2.6.8"
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    cross-fetch "^3.1.5"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    cross-fetch "^4.0.0"
     relative-to-absolute-iri "^1.0.7"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-dereference-rdf-parse@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.6.8.tgz#a40c59a0a0651847c21f9e47bc011285c1217d3c"
-  integrity sha512-+ntPX8PD1FuM1peqI5I8YliVHsotgMzqCbEg5gPBDX3UJ5frYcDKWFTsTway8Cx6MXP/79+k1Rk8RethlCzD8w==
+"@comunica/actor-dereference-rdf-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-2.8.2.tgz#8279645060aef6af22893fdbd7c67c122921fd39"
+  integrity sha512-/jMUiTUuizIF5fCrZtbCYv4HWTU762TsYEIf6slmr8DyRum8DKzSL/ototK50bkush9xltFL/Kmsvhp0fBBFVQ==
   dependencies:
-    "@comunica/bus-dereference" "^2.6.8"
-    "@comunica/bus-dereference-rdf" "^2.6.8"
-    "@comunica/bus-rdf-parse" "^2.6.8"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-rdf-parse" "^2.8.2"
 
-"@comunica/actor-hash-bindings-sha1@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.6.8.tgz#6acfe4529c3399ab36db9ef5ff27ec272b0ca286"
-  integrity sha512-O5linMzavi+L4QC7qRxTLw6C5AXReRJsY+PdIilIEy3XgQCnjZzgJAdn6x9ix9iL56bqaiySIGgAU10WJ5hzqQ==
+"@comunica/actor-hash-bindings-sha1@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-sha1/-/actor-hash-bindings-sha1-2.8.2.tgz#3540d8a4b1216d25e95484dfc31a60352c015df1"
+  integrity sha512-JwBY+edoVkTleEMhQjws/ojOSTtVvO1PY0jTfBHh8V5d8c5V6XodJs7AshMbnss3/qu/6T11aIUSyyBDepkyJA==
   dependencies:
-    "@comunica/bus-hash-bindings" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    canonicalize "^1.0.8"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    canonicalize "^2.0.0"
     hash.js "^1.1.7"
     rdf-string "^1.6.1"
 
-"@comunica/actor-http-fetch@^2.0.1", "@comunica/actor-http-fetch@^2.6.9":
+"@comunica/actor-http-fetch@^2.0.1":
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-2.6.9.tgz#906da721a81c5f6f9af7a84e2c7459db59caaef8"
   integrity sha512-p3JPL8Ms9WjG/YMXeYnQNFFYU1rQ2BAlPcKc4FmdMuqg+fRtNu/VnGX1+Thxp/fF0CZlOy9Z9ljIt8LyIkvWKw==
@@ -395,6 +411,17 @@
     "@comunica/mediatortype-time" "^2.6.8"
     abort-controller "^3.0.0"
     cross-fetch "^3.1.5"
+
+"@comunica/actor-http-fetch@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-2.8.2.tgz#a9fd75cdcb684688394bb7fe35c99749b959732b"
+  integrity sha512-XKPWbWihnBGPn3fnf7kxq2wVENDbCtTOl+9hFgsspoh1ew8fc0Fri85iE5dE5Z82s5PfW/oxQBFZVeiwKHwAZw==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-time" "^2.8.2"
+    abort-controller "^3.0.0"
+    cross-fetch "^4.0.0"
 
 "@comunica/actor-http-proxy@^2.0.1", "@comunica/actor-http-proxy@^2.6.9":
   version "2.6.9"
@@ -406,918 +433,971 @@
     "@comunica/mediatortype-time" "^2.6.8"
     "@comunica/types" "^2.6.8"
 
-"@comunica/actor-http-wayback@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-wayback/-/actor-http-wayback-2.6.9.tgz#317aa7963772079d5dce4979be68d8e3239ca0f0"
-  integrity sha512-/uggjsItvMMfJMU9b8BVBZEbS3O9RHElssgWlJ8CebuQSDIIYEIdZ3yHHsySyhqJ5OTl3BalSZWsZa/lUdKhEQ==
+"@comunica/actor-http-proxy@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-2.8.2.tgz#aec3147132934649c969c7e586db390014e66b35"
+  integrity sha512-OOFWfWVdi5mpRRgrNIqFx+C1wv3ulcDaBYojzbQdktwl6Vsz79Hlh3EHsgyTVxKHLjuhGeb/3aNbj2cFMVlF+A==
   dependencies:
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    cross-fetch "^3.1.5"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-time" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/actor-http-wayback@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-wayback/-/actor-http-wayback-2.8.2.tgz#37c6ea96fc71f15133dd810e1d2b78ff25241e53"
+  integrity sha512-rTb0srYPLAv2jGLXEyT8bFbqiasUSpQiC/Mu3eezJQ4lXLe30gmiaiw+eBiHmNeX1TAp4By2IAZbxgB/+Z3lCw==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    cross-fetch "^4.0.0"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-init-query@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-2.6.9.tgz#357990b524d4a3f59aad4b59301d2956f23ece2c"
-  integrity sha512-rvahsWdyW0pYVDxf5wdJE3CpqCkk1d8FiNMDl3hz7t47m8tAPpp+EUMxXoODiTiHAfC8mKb1soByO9rXqMa37Q==
+"@comunica/actor-init-query@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-2.9.0.tgz#23508587d51820759c119091042666f8b6eae88b"
+  integrity sha512-7ZOfx2KjKWXzUnjWRSggArAF1ati2YjezqV0yf1nxUVwLyb2+Pwjnojg8sOc0jEpb0HRihZJO2ERDmsqKtg3fQ==
   dependencies:
-    "@comunica/actor-http-proxy" "^2.6.9"
-    "@comunica/bus-context-preprocess" "^2.6.8"
-    "@comunica/bus-http-invalidate" "^2.6.8"
-    "@comunica/bus-init" "^2.6.8"
-    "@comunica/bus-optimize-query-operation" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-query-parse" "^2.6.8"
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/logger-pretty" "^2.6.8"
-    "@comunica/runner" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/actor-http-proxy" "^2.8.2"
+    "@comunica/bus-context-preprocess" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-init" "^2.8.2"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-query-parse" "^2.8.2"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/logger-pretty" "^2.8.2"
+    "@comunica/runner" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     "@types/yargs" "^17.0.13"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     negotiate "^1.0.1"
     rdf-quad "^1.5.0"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
     streamify-string "^1.0.1"
     yargs "^17.6.2"
   optionalDependencies:
     process "^0.11.10"
 
-"@comunica/actor-optimize-query-operation-bgp-to-join@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.6.8.tgz#055cfc65cd61d89f4e688f92331dd747625dabae"
-  integrity sha512-dcDSxzlJWOkyaB5TcRgt+hUdWoaPJHxhXBu/0ngxJ+WObn5Fi/Nyt/MZAaJQR2HYzSKrVN1UeFnT02w8GrjsPQ==
+"@comunica/actor-optimize-query-operation-bgp-to-join@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-2.8.2.tgz#f21281f1d9b9282ae56b78b5ae289fcfec54c272"
+  integrity sha512-ECTnXBeDc3d2mgTYobuPGpxh0jRyALVsju4gcwpu50IADcQWmoZ//fvscIsYfnly35MLL3QpxNOO4FeaLtB6yw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-optimize-query-operation-join-bgp@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.6.8.tgz#5078c21314452a6d62e94e6a4bc36a6d65f90c51"
-  integrity sha512-fPp4erOhwPa/X+/ZTrXEEknsk+JFnfKVbTCcqKs/Atl6j4RoX6X6neL15/atHlsqwVPEY7vKlBLzQ5+lpJ2fTA==
+"@comunica/actor-optimize-query-operation-join-bgp@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-2.8.2.tgz#de954c32e40f699b2c9ef53be4f6b5b9b1a4396c"
+  integrity sha512-hDnimckCwvDOFTCeqQR+iR+seDoJRvl53MgiXxlywmspJNpCKM9azTE2Q4Xii1VmijsZDCEt55yb/9nQClNrTw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-optimize-query-operation-join-connected@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.6.8.tgz#02e936964931858d3e642e970793965a737171ca"
-  integrity sha512-m9GNNk9bYD3xmUckvrin03kD/cCd+mpzLgn5HCHKYHoXVNo6mdz//7NXNWEZPq8IS6YVEEKSo8JXyGiLrWzDqQ==
+"@comunica/actor-optimize-query-operation-join-connected@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-2.8.2.tgz#facc3cc231093a1a0fb7489a2d0c9c45588129de"
+  integrity sha512-KEjOHKS4M0LIuJZHRWSED1vKc7rEzmJ+T1ByqyTDvURfnUEl0I6KOcfYfpiWELfSliOSFBLqirwlrJvSaYN8Ug==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-optimize-query-operation" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-ask@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.6.8.tgz#1964179cf25174093450d8fa87b4fcfd0b083901"
-  integrity sha512-ceauwrHq41qDJs5uLv0EO29fYPAMFkU3QBobzpq4CknKzvbr8sR7z7o4fkfBTmGt1EtTh9HkydCxmaYvagmSbw==
+"@comunica/actor-query-operation-ask@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-2.9.0.tgz#256388face2ce322f9f3f35b923dc54abf027f6b"
+  integrity sha512-ZidenVEKJGUjXosl75VtCDyHyVlR7HUTBN1Y+o68ZIGTfES+WizFFLGarGFUUsbSEJs/rwhms4fe6TPuDjB4Qw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-bgp-join@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.6.8.tgz#ce5e2502a6940777ec53acaac134021bef88bd90"
-  integrity sha512-1pubsXA32Drp8ATSfZJwRYvOf0jCH5FoA8TulcGT0xl70HqBm0QEvkkmtyS1uMDCkLQOIDZpbCt//7rb5VG9eQ==
+"@comunica/actor-query-operation-bgp-join@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-2.9.0.tgz#fd93442c379f1c069daa6b71aa720fd52e33ff84"
+  integrity sha512-1w6CNfh3G+n5946pu8CksT6mbBenR7rwhwxOZd3izvRIkBCmFNYhQoSTJcyoxu+Bkp95GbXpsMO8wjQsov7ezA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-construct@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.6.8.tgz#99ecc1f7f76eaedb60812010b1aa88c0a946f32c"
-  integrity sha512-OH8DoWPH5vAJuhJP1B6+fGIoP7o1Rw/++PteF7YbxFsSWu7Jhs0Z8DDuP4AQMc62N13iEcbL9m7+AxtISPYM4Q==
+"@comunica/actor-query-operation-construct@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-2.9.0.tgz#4e8abd064e7d92ac91520b6e92dddc25bb6c27b7"
+  integrity sha512-hfgCgN5ky/rhCNaHOt3KY6m5cZrfd0GO3/gb6Xk69do8MPqUxkAohwAql8DIysXCs6vfDDe8Xi8W8by6X6wsvA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-describe-subject@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.6.8.tgz#48b175d86f20b6cdf12ce91664d452f677c64e0a"
-  integrity sha512-vkow81b3YXTmy8D57UvCqphFz1Yn7C/QsR1V6Rk/6Wu15Nln54noA3aiWxhjgqkeR+Qe0hijUfHgPj5TA42U/A==
+"@comunica/actor-query-operation-describe-subject@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-describe-subject/-/actor-query-operation-describe-subject-2.9.0.tgz#6804002e6fcb9f729f1b5c668080e43a63405fdf"
+  integrity sha512-1h6QFLijFKgZl/PRh4tBYkfGv/oAsY/itX5YCjk6gvHkYh7P31YyzTOZY5fJgJtK74fClFpORtfey7lnd8OCyQ==
   dependencies:
-    "@comunica/actor-query-operation-union" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
+    "@comunica/actor-query-operation-union" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-distinct-hash@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.6.8.tgz#55c07f3707b2a3c5f9e7d3047da814ca6771f4d7"
-  integrity sha512-lZe3csN0+p88ADnH97ljQoZ8+qKsY74Zsi9nXXNM4s95Z3HBtVoZD3KgiH1aEMDEomfb7rqwNA0AaXi40h1rKw==
+"@comunica/actor-query-operation-distinct-hash@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-2.9.0.tgz#8a8fee00d0139af24b90daaf1750e9f0ef4cf8bd"
+  integrity sha512-djMP2j9OGFk6TL53KzaDx9BuZ3Xj6ZaNxDwfpv9TKo7y3cS2NRV6t3ndWIj9yJEn4E8s/WR3ups0Eb2JAozCIw==
   dependencies:
-    "@comunica/bus-hash-bindings" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-extend@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.6.8.tgz#169a4c7a248328b348cab71155abd4c3edab8359"
-  integrity sha512-TrKsWHs+InK07s+cD2APP+rz4Sj0Bu1cYMXKdGywOM9XY2/zS4gLyoyG/r+2pm9kQrxMnrKo2zMA+t8OGTsxCQ==
+"@comunica/actor-query-operation-extend@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-2.9.0.tgz#43746bb2ac86955feb8daaff4f036c1fa77e29d4"
+  integrity sha512-pfGJMbM/mmfcEnGkTDm0nBB+Ea/EH7+UW6+hWXd/ibyXjtYcLK/kz58MfGjOalodXKAkyVEzE7eD8TKgd4BjSg==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.2.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/expression-evaluator" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-filter-sparqlee@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.6.8.tgz#c1b8afab58c7b45da1240f0bbade4ffe4271222c"
-  integrity sha512-sPcsIjvoIdB+dmxoP7sGfPlHO9iSotgqY18AA0JwGjbhDSnRbYq5k3yRhxMsfP3YRjbyUYyrS+4sE4KVcdKHIw==
+"@comunica/actor-query-operation-filter-sparqlee@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-2.9.0.tgz#c5ae06e349cabcd3bdcd924a1e01736eed5765e7"
+  integrity sha512-Sa2mtcmx1htv2jKrd9dzu6TlErppzhBNku0ZUxhtKAwI3SFM5+jK5lokkZSRM2KM/GPFcsXvcj98ACBND2GG8g==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.2.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/expression-evaluator" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-from-quad@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.6.8.tgz#44d490b8ada8c335ad97d2ed5fad26d061b42a65"
-  integrity sha512-tIM7vk5Ev59hEbXQDlpRB34PuaLI1fyo04ruVLpu4TKgm21HdfL2/EmA6p2PlXovsUrz/VJl+R00+INsklbuWg==
+"@comunica/actor-query-operation-from-quad@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-2.9.0.tgz#400709a7551d493931ef9caf7a93b5f2acf48c0f"
+  integrity sha512-3bHJcGZI4Jz9BzKER1daHXqFdp7njK+O9lGtT0PkPJaZTIXO9bJDmXJdLFQYqx3dv7INiWzXE02zDDZrT4D8Lg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-group@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.6.8.tgz#1db7916a3a0ff638bf55853474766e5da103860b"
-  integrity sha512-moA4QmlBbrqvG8YQ0KT56VfO1m4IKy9RBxcZNizaz5yVL37Kovb4RML7YI3kRWOy6cCyB3LwczgKk/nqZPHrDg==
+"@comunica/actor-query-operation-group@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-2.9.0.tgz#eacae761736b7fb313a9f6b3523a6caf57600209"
+  integrity sha512-FjdHQWy1xCOYeg8DnlPDIOEIk061542Qsc74TcCCefW8J+0bjWbfbF3HTntFEjgM0uytFrtNF9ITxk+wiwb6sg==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-hash-bindings" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/expression-evaluator" "^2.9.0"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.2.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-join@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.6.8.tgz#0de54e2b61ef629baadfdb5502cbeaf2a776cecf"
-  integrity sha512-ppDkUJPgKD2z5Z5y/0eYXQ/l/iFV5+royvYacH7w1MeF5SSijib0buGzI14dvoNWUz2fAlFnnUpXMZWDRALbWg==
+"@comunica/actor-query-operation-join@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-2.9.0.tgz#16a2264546077b043d37409451ef46ec720803f8"
+  integrity sha512-xs7oFa0tNh8Md8mKsShOjt3zXATJrq3BAAuIsbTb7tDeKfmburyP6qFYA8cmTx1GE+uA0KXzo5BAA3Q45Cqn0Q==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-leftjoin@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.6.9.tgz#a50c9c7a8554c2512a520bc35071c5daa8812638"
-  integrity sha512-UJzg4yV+71Nfc4TvbtO3S3P+RgL/tR0VSkl+HaKqMMiQaa/jrScHtVuHEwlTygA5o23iZB49fWMDMbLRitx0xA==
+"@comunica/actor-query-operation-leftjoin@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-2.9.0.tgz#40960f664f6e429b944fd25c7c1e2c0e93091bce"
+  integrity sha512-JhYGAZb5DmlGAve+HLbPeBG6ZmZT+ID7EfhJx7sChHlbpmHlY7grq8M3fNw9A1tdZcVVILoMvFFV07gih0fDcA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.2.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/expression-evaluator" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-minus@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.6.8.tgz#6a3f6ddfec78bbb540d9e18608952d1e37a9c593"
-  integrity sha512-+gNbztXZsj+czAfcy+jzHmyR64H/pljexeTWuvlHyXZH6dgNFA+bHum+e5ij22jKrPhOXJnBhVKqjkXZk/rCEQ==
+"@comunica/actor-query-operation-minus@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-2.9.0.tgz#fdfca376117dcc0f672ca315a3c0fd933688e37b"
+  integrity sha512-TepoSg+anPQVSvez9tG8yqppGrufdrNrjpMTCdBwht7DnCC0nwcTXA21m73YnTEeXugHHH9ze+jZoY0Zh5Q67g==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-nop@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.6.8.tgz#533672db855f1b139f2801fb3bd6d94df18773d3"
-  integrity sha512-o6bcOvZEvJ/yZXyf25yXFSTF/NqqLFBGVwsV6OjGO7eUpXuM7thTw4QoRvz/9XIjGjY8KFAF9tKU3gfp1ZCu5g==
+"@comunica/actor-query-operation-nop@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-2.9.0.tgz#154a1968ad01c27f0541c6c8ea2f153a3c2944d8"
+  integrity sha512-Z+YMf9nGiQDXpXcXgIn+Qlw2G86OT5A5UiFMaQNBsNZ3uIV5c15uwcV6fLqSETwZdE232i9ZUX1BRqowyBYUxQ==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-orderby-sparqlee@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.6.8.tgz#aa90ffedf285214a128e0dba31ceae2401be989d"
-  integrity sha512-6FOHIZDCBjjqdItMeHkrIFOh9rE7oXAVV0ocrEXdzUkbLN5a663YFqZFPKwrm+cF8gQMMApecEU5lRv20IaxWw==
+"@comunica/actor-query-operation-orderby-sparqlee@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-2.9.0.tgz#f313d31681185e70b385f0b7437c9b7a97342a87"
+  integrity sha512-tLPrgRxAeLPkOn60lCyf1EIwb1y6Rb/jSjdYFzo0vdrNrGWJM8wWmK39EtYvEnWYzZUluQu5pNPOKDQtrDnssA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-    sparqlee "^2.2.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/expression-evaluator" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-alt@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.6.8.tgz#f22c218c0aa0c32dd39f21a1e5ad690b79f9a0f6"
-  integrity sha512-+Uwl+6qmaIJLxte1NXrhuvxnhcF21foUNG8z2fCGM/FpEADw83H4sPp7Jvqxf4ZNZDJUto2GOPz/cW2Z5Hu1KA==
+"@comunica/actor-query-operation-path-alt@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-2.9.0.tgz#8c083c2397c1b2c7d47092cd4179701d6251abfc"
+  integrity sha512-0wfe5/w3Tkm2HySmWgmV9EGlK6GjZmeEiFMRePLR7lJIXKGaa8yMndErhIzZsDvn12NH0U+in4ij6SKgFQGP1Q==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/actor-query-operation-union" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/actor-query-operation-union" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-inv@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.6.8.tgz#6c9075ae94255cfa1d51f4d6b67e63cd8d6e3141"
-  integrity sha512-oCujYqtF/AkTRVm7O6LASGcq+7XEAjrKO43DdC03m1yKbLgOA+bFQW/Rn14ICTKSBs4LKobODrvUZGkygA+8vA==
+"@comunica/actor-query-operation-path-inv@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-2.9.0.tgz#2f34b15fc2424768bce89e64de6f11affd1043d1"
+  integrity sha512-SDxj6Uzo66FKSTt4Qbmeu+zLecBapRnd2JKHEJ6Pbi/+UwCAdK04VqLVChyMFNYQ30fVGnUyA2ErBWU1ICsDug==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-link@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.6.8.tgz#a0a8cda9058d5e262494ed4a5a8dca12146affcd"
-  integrity sha512-adoCUF9fCqJrNUbkTj9UEe3jLmNHZtKtC6RhyqwRu2Wgidl2yIC6UWfNUWVhyxeGlO0a8KvgmRGRywVXGArRgA==
+"@comunica/actor-query-operation-path-link@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-2.9.0.tgz#84f61e2824797e6b5b5b78b4f4cbd2e491c27851"
+  integrity sha512-w4nal/IAN/0qNwjuzecguRZqdhs0vRpQK79zfdmgkCHGM/Sn0seV3iwShgOhvLghcW+qwyKxkk8ZrGNyjNNLmw==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-nps@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.6.8.tgz#143e9b8008fb94c11829b8aa591926bf89d38ad6"
-  integrity sha512-xSe9i+UPe3KuA2m66sU62cdfN8nASZcliQj8VcPt0tgozBHu0XeiaCDfj2FbNDtYt/ZeBtXztkNsvVHSAWAKwg==
+"@comunica/actor-query-operation-path-nps@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-2.9.0.tgz#d10aa55f4c7b03d6147331ef5583691e4b2633cf"
+  integrity sha512-6nWhRPBsQtID8dfdv4WxskpDtF247xd2wNVmeEMC9yGUT1u1c5GXZFueXSEbBeUpHMPIYkkK0J61KCRzjI0T/w==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-one-or-more@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.6.8.tgz#e89d2c3e2be37be833c45a2c0513882487894117"
-  integrity sha512-TCyHXwOsNbOEP0KbSS9GHBDDWTAyCJ3SvKnX/3evigMCKsAY+ZyFAyA5Tp0aTkIs3QYUqhBAgLrW9Uo5CLYZoA==
+"@comunica/actor-query-operation-path-one-or-more@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-2.9.0.tgz#88b7fdd6bc6c58bd42b442dedc7da537745619fd"
+  integrity sha512-r/5QfWYaMPKM94MWnEYg1YCyt2SnFFrnUC3mMm20s4eIzKa4SkkgncomrgjcVyHlus7JgWhMq8DXDzCOxk9P8A==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-seq@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.6.8.tgz#0f48204dd39cfa6fd3af8dbd361650b3299bf337"
-  integrity sha512-FFhOS7+2o2cTpUVjenEvMdSL9zRgXjB0KSNlAnu8MvolHkfrWmX+RLRL6xjWP4dSESpUEAUttHDAzhfAQS+7WA==
+"@comunica/actor-query-operation-path-seq@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-2.9.0.tgz#e62fde164a84592767ad73136909e68ba4d45b74"
+  integrity sha512-koPMW9yWM2MCZUzSXl8biQfnM2xuW35cBuoCUK+n+QAXwJnsPxkm/uZW+MfRfhYd2YbnycEbzpfNq6zChPVVqw==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-zero-or-more@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.6.8.tgz#e8d00d1d4777db99d8a2cb2c40a8a7916cb78d29"
-  integrity sha512-fQkWNI+/KB+mL7meXt0js4jJlxCR7Box2jx6kpfPFd5B+kGOBgX3x8unHPnPz0SF0nlaoA30OQOD4xeYnyoysw==
+"@comunica/actor-query-operation-path-zero-or-more@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-2.9.0.tgz#773805e2b5e8b0dc4f658b09951f29b3c6e29e94"
+  integrity sha512-lzk01byqqCkCGqIziazGyEeYr2Ht5taXK4czYEqbe6igsJ4JL8Gfql9FPm71iOHrSbp4V2Hs1S1SmADDM45YWw==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-path-zero-or-one@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.6.8.tgz#b6d8e7f49097cd4e5eeb2f738d83463b55f83a0a"
-  integrity sha512-XEi5cFg0y0/zgIiV1i9im+7EF0nAe5qyLyiNM+p02MzgqFQoncAmxC26QrQhi1D1aZu4w+ysv4eoQJ9dIjWHtg==
+"@comunica/actor-query-operation-path-zero-or-one@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-2.9.0.tgz#0319a7cebb2759254a36870fd7894f46bb8a0d71"
+  integrity sha512-mjXyB86HMmVairepY2d+gjO02ITAUEDj48reoJ7nzUBe5DO9Uokg9srdKueQuf/i7Z4Jy2hl90dKVzUqXQKe0w==
   dependencies:
-    "@comunica/actor-abstract-path" "^2.6.8"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-abstract-path" "^2.9.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-project@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.6.8.tgz#92cc3d9d6d52c8f409edc393927c4d38cc05c4ef"
-  integrity sha512-gzlBGq5YthIxvFSUf2zsFupOiFSd6VvO4gml/61tLblz3AyikC/7Zk3+9qsb+IeBaqNq26dA2PTkP6FwhEXNig==
+"@comunica/actor-query-operation-project@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-2.9.0.tgz#dc5b16194bc7862bde38c84904847bd8844fa0b6"
+  integrity sha512-5uFKETsTMgP0dm0Y7gZt7dtJC+NfO3IwvCn7kmgidxiYhlghX2dOHHOxa4NGeVlxlLsP0DtZNZwUS/0uVIDzEg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/data-factory" "^2.5.1"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/data-factory" "^2.7.0"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-quadpattern@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.6.8.tgz#e9e34178721b37774303006323f40d2220580744"
-  integrity sha512-RDiLSfBsMb/Eaahfq9wJvsVVWyeUAikGPR6ZNSatKPhhSIqLFUcbhqSj9f4lm0gwqf3eqn8tZILTZnPg7x8RzQ==
+"@comunica/actor-query-operation-quadpattern@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-2.9.0.tgz#052b609b57f7627e0d90a4a34da50243ac858bd3"
+  integrity sha512-GagxKnFxua6hrld/SMugRu/2+re6ZMUS5FvtWmpTyuNA5vd6a7EocRj5CPeBz062AiFj3dw5qHVm9KS2M+EfnQ==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-string "^1.6.3"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-reduced-hash@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.6.8.tgz#7ac1b5ee8cdf8c14a2fd5b1e439e0f1af4f1e759"
-  integrity sha512-hnpMau9/e/ylRzoH4PRANpLU6ZVWX58RW9wnVFIHclFzMMOtLXeYXHVdCWlsQp+rYBHUFD23RT51qHpzHXxOVw==
+"@comunica/actor-query-operation-reduced-hash@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-2.9.0.tgz#d4d02a5b33c98b4dce8e3ded555ba11d4c3591a8"
+  integrity sha512-0yfDRfgxWK7USih0EEizspXG8bYD/+tZDjhsiYBqBleMhFLN4Gk9YZgy9DuCoEY8EODUZO/y72DyzgzMgtQ0Aw==
   dependencies:
-    "@comunica/bus-hash-bindings" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    "@types/lru-cache" "^7.0.0"
-    lru-cache "^7.0.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-hash-bindings" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    lru-cache "^10.0.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-service@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.6.8.tgz#d1eb7b9814d4bc71821755163a600bc9df8245fd"
-  integrity sha512-Sw2my24KjzagYJl3gDSf+SkINZleqgYPkrE8JXA0uiIJ/5a84w6IzIgW6mWwpMb7DR7EYiKD7qU0iB19+9gxhQ==
+"@comunica/actor-query-operation-service@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-service/-/actor-query-operation-service-2.9.0.tgz#74f9f76eb7d255ad99ec9a035b5a75b8a9d4a96f"
+  integrity sha512-K7uVBzdiidvP+rnfy+UH5DSMn8Whs/47Y/FHRBGJCfjAjU4XgzEpPUYsqE0BrOBtM7k/vp9CwHM1kDlKX1o7GA==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-slice@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.6.8.tgz#5c29cac0a34c52b7c24966f750ad8530b41296fa"
-  integrity sha512-/0kshF512Hb1PzDxOTAmESxSBWav4kb8bPc+H62m5cLK2HXy4PM4TCCTA68LgqvLVy1dojeM5DNZiYKSJGxrxg==
+"@comunica/actor-query-operation-slice@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-2.9.0.tgz#da519644ce77fd5312484b8a241a4ae3558e18df"
+  integrity sha512-ndGWtzhY41RP+sLerNWDta/BsAe5EHTtw5ehB+CG+rm2AyZTLPiYVujjwWCNHavQjruPYN/SPXaVBfBpyk9QPw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-sparql-endpoint@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.6.9.tgz#37d18dbd69956be61e77f8dd324521641d4a0999"
-  integrity sha512-ryzf915lB6ALG7zjbKrKp4OJ/JASjSIDN4J7xAeL1xXNXKEwKfjMXM2kLrCHF9RvTP6ovA8q5u07aUFKVM/KfA==
+"@comunica/actor-query-operation-sparql-endpoint@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-2.9.0.tgz#9d21fb4d3e7c4272dd82ae0add63cab93b3f2f44"
+  integrity sha512-0TWj3ieuZdfmIR9YbbEJl0rnyB6RfEplck4jIgYysPQpgoXJWTXEAHIhoQgQ30q26SaGrMyjAmPq9BMjOqPE+Q==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/mediatortype-httprequests" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-httprequests" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    fetch-sparql-endpoint "^3.1.1"
+    asynciterator "^3.8.1"
+    fetch-sparql-endpoint "^4.1.0"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-union@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.6.8.tgz#a6f5da32f68603b76107d10e92e840bbc37c8d58"
-  integrity sha512-MHjo5aXG6cPEjqRQ7BTfjVeU8A02s6IZsY5luAnYU2Kb50Sc8qj75ljOdRAGDiQLLjX1kKCq+Kc4I4h77uFKNA==
+"@comunica/actor-query-operation-union@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-2.9.0.tgz#c4fcb8fe04723a0889e2f3aa6dc3d969be5aeb83"
+  integrity sha512-pT76OxvEG1S4Df0dpVrUcLfojEAy99D2gk3AEv1l8K5UNettH1HK2NsG0+kBN4scu1G81cXghFvg0BTiyrj3vg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    asynciterator "^3.8.1"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-add-rewrite@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.6.8.tgz#07781fe8a7a518f4f70f855e1f712f5c2ce94678"
-  integrity sha512-c8q5Fw5BmhhzaGkTmG9GE99LXHGvpXzwNlSqylDXXHEM/H/PHzLqQuVd5qY4m0i0BjDsJ6rvj8ZZGaIf8f2JMg==
+"@comunica/actor-query-operation-update-add-rewrite@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-add-rewrite/-/actor-query-operation-update-add-rewrite-2.9.0.tgz#3d4b7d846bc24bbdb0e6711716ba50251e22988d"
+  integrity sha512-5Y9euKhm455x0hXLCf23R6gVQJwuZYV5oAx8jVNCyTrlNAVd3MlboA5aV9aIRC8cGScT9BM9Y/ZBHgANjfhJ5w==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-clear@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.6.9.tgz#a6cc6fc05f7e9be83d838d75fde4cffef0a8293c"
-  integrity sha512-qytm13fhB1nbT3jZzzIonQZM4sw52G9B0yur2Hy5RcFL7oh2s0lJj220KGhzr4Q2DhalOo/pNcRhlJCY0vifbw==
+"@comunica/actor-query-operation-update-clear@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-2.9.0.tgz#4e0eee2e608773b08ce10cb12ce4d97513285046"
+  integrity sha512-Esz4ghxRocXlSOmyF0bKntVudmbnSOAJMswF9DIVPmAWDO/SFnWHOynShOnZzKXbWUt+mRKsg+Fz2OEIqaLzkw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-compositeupdate@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.6.8.tgz#80ac41e5d5723614d27793442f8d428dedd6d297"
-  integrity sha512-m/kZli1pds74ZeAXQSS+qDEl6bn/4fvP+fygzfYreoty8wjyPdocgaMmQyyrHdnYCxwSI3RKbRV5DaYw35+Wwg==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-copy-rewrite@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.6.8.tgz#edfd47409384f0d819f07c414e21442caf9d91c7"
-  integrity sha512-orA7ElJMR3FsOMvHh2Xj4o1FRt4GhnvaIiIXcjziJMgZnDj2dpswkclL1ALawLlRFcT7G6Pc7rff/mrAE9ldLg==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-create@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.6.9.tgz#38768773ac99a2bfadfb835464a25e5e754a0931"
-  integrity sha512-ylA9sIUO5a2Gm0qg8xZg6uH2E1tYQZYY2h4ZdDoxDmF8jjiXQz0xxzg6i6CKbY1C8iYMqPgEj9UWDBjZv5Ab6Q==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-deleteinsert@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.6.9.tgz#0cafb2a94ae2a68de31fb1f285086c7d2f408d14"
-  integrity sha512-eOy2cXeJv+e9D5irP++wPglmZ959d3I9qN+IVKyCKFreaYZS+rR3+e4gR1Z6HOgX35jhE2i1n4sNfGdXuRJDpQ==
-  dependencies:
-    "@comunica/actor-query-operation-construct" "^2.6.8"
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-update-drop@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.6.9.tgz#c73c4d883ef5b07939ef41bdb3f4246c0d0a02d0"
-  integrity sha512-MwsxZzPh6eRvkqYqHb1Axt8bLbslRcd6sZuzQQbiV7i1WaqGqEOyWBJZYT8zP5MjEcy3hQQIgj49+GBaHAsP9w==
-  dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-load@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.6.9.tgz#67981001e08f8f306926810173e31ee019cd948c"
-  integrity sha512-3PeXLgXOAwZygiM3LpGWPAJddMAYWTTxW7ANL1QfNlS6II4YwUUGoYQXOSY75vWoT7gtpLGVEpSNbaUxLbS41A==
+"@comunica/actor-query-operation-update-compositeupdate@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-2.9.0.tgz#426b4494aaa92aaf7d8b6ea03e691a12af9f8e64"
+  integrity sha512-fEisHDEmKDlL3vCSPJEjR9dMgN3CQXClBZQNTC74sSnGd6+iUFuUUrfhI6DC3s4fRr3P3L7yt7q/6HVLPpbkTw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-copy-rewrite@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-copy-rewrite/-/actor-query-operation-update-copy-rewrite-2.9.0.tgz#9eac33b2d6f6a97948f45466a5a9b1241a649320"
+  integrity sha512-UQKpssa/498FrtcHrxRZy+3Q0rHdHEU4UKekRT95t4rUFhpHTyrnwI/TeKJTWa/5iDnRd7PxriKAnTO98Mxz9g==
+  dependencies:
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-create@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-2.9.0.tgz#7fa0e7f3e01074559f5740e31aaf0d06dddbf586"
+  integrity sha512-Ibwcae2FgOkmnBmORDYYKWRuX4AG+IawpRqouJjEQpaR8ZuYRWqmjLqQNzPcHOMEwovTshPp66F/i25LZQ/TFg==
+  dependencies:
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-deleteinsert@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-2.9.0.tgz#d82c3af4fa69872c723801e55bcd744beb78652d"
+  integrity sha512-RNVR2DoLQacbj/mtW8qIKmfUmEhiTsev9S4Yd4g64rt/wiISYtO66CJBHxh9Fiy2wyO3OeLGVbj/MSeeg8FI7Q==
+  dependencies:
+    "@comunica/actor-query-operation-construct" "^2.9.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-update-drop@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-2.9.0.tgz#89bebfa39b04a78973ceb9b5570ca2df28bbbb68"
+  integrity sha512-FCKMtWj89fcywPIp9SAhiTEJGLpI+yXIhIlz/lA44WFzFrqRsGK9unrHv4Xy20LZWZk6XavaQrE2Sdyw1LJGSA==
+  dependencies:
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-operation-update-move-rewrite@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.6.8.tgz#642fd5eddf4e1fe028f8ca0edf742eba6ab56f15"
-  integrity sha512-kmfwRIuF3Uj5zFC40fB45G/MLisCP89zgRSW1G0+9mK30UyJPg/bZEbWGuk1i1TUo1YoBBhBMT+hE+A+cdRDvA==
+"@comunica/actor-query-operation-update-load@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-2.9.0.tgz#d9113bd0a94f9c697bf2fd88a873734e93501288"
+  integrity sha512-4i2ngHJOrKDDt3BYuTyOxraqKLbLqxu7uZKgpF82RIk/JgySFWHbsn4KTdhZ3FRNdWeW0c5BXk6Igt70L0RQKg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/actor-query-operation-values@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.6.8.tgz#a3ed1b381232e385d537f05029477f72b6ff9106"
-  integrity sha512-WxpXmYVVb6NAXQNieLPc+z7NbHiX0hf4d97xHjwbzxpB7/5SIJsEbFkTgezZZurXYrPfb/PA39bMycsKhYEUGg==
-  dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     rdf-data-factory "^1.1.1"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-query-parse-graphql@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.6.8.tgz#8c68e82f422e9092f3c4b07075554d1eb379f67f"
-  integrity sha512-xN/k9j96/dMauvdMoprMbPd8LfWOUEl7CoSIMgaCJAlGl4JhMwQcfOLrBO1CyzW0AGR11JZiamg5M6LXIh3HAw==
+"@comunica/actor-query-operation-update-move-rewrite@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-move-rewrite/-/actor-query-operation-update-move-rewrite-2.9.0.tgz#80f9a576e0db2e706068ffb5895b966f553f0982"
+  integrity sha512-VEy9TgdbtluXXpz4/zMZ+NIKt5McRJD5LVcfD9Sj0e1PFY2nO97ar5v2QTUWM7eddV0dHHLP/JaXAlgkce8Xhw==
   dependencies:
-    "@comunica/bus-query-parse" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-operation-values@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-2.9.0.tgz#52087112a2b3ea9fb8dd8822a5eaf0084e0ae254"
+  integrity sha512-UbQ7vWoSfbMOJ75GhX0jb9agFMumwujaZiV+dzm9aaAHQcC7qw+wzoLPRKjTuD4V9wyDBe84Q4BAPZSYG2SXDQ==
+  dependencies:
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    rdf-data-factory "^1.1.1"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/actor-query-parse-graphql@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-2.8.2.tgz#926ecea49c07b43087637420d41edfdeb857d016"
+  integrity sha512-XDyGti12+Sz9iQkO1tzoM7rO4FlcTSN2S3FgheJXIb+Ebx5L9j/31xYvROvM1XIEKTWYex1F7mAOJzwVGalqLQ==
+  dependencies:
+    "@comunica/bus-query-parse" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     graphql-to-sparql "^3.0.1"
 
-"@comunica/actor-query-parse-sparql@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.6.8.tgz#eb54e508db5c3ac6f074a9f462073a8c64115a9e"
-  integrity sha512-43QHG05zWZA7DancxCZV6aerJmUg+5TEwCZk8NN0U/TozuV3mwfgKa4n5+OCljMX44wpMCdL9fRKC9HOfFP22g==
+"@comunica/actor-query-parse-sparql@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-2.8.2.tgz#a123ab23ff6addc13bb6987448f1ea8e863c27af"
+  integrity sha512-qH2fVHTX93UwtIeQKL95G/dWsLD3ThMA683hbfv7uZZwQv+SEE0MvJKcz+jcZlqtt5NWlIPPKz7TM/vL2Cf+Bg==
   dependencies:
-    "@comunica/bus-query-parse" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-query-parse" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@types/sparqljs" "^3.1.3"
-    sparqlalgebrajs "^4.0.5"
-    sparqljs "^3.6.1"
+    sparqlalgebrajs "^4.2.0"
+    sparqljs "^3.7.1"
 
-"@comunica/actor-query-result-serialize-json@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.6.8.tgz#f2ab1faf4d8d186f7000b38a9ed35d50b303415f"
-  integrity sha512-bnc7Mhgpx8PII9ZZHKNrHhF3yFZXH7rAPINjTMgy6zLRN7v3BLOOj0pS8sb8T9fpgnxbmaU8t0aLnK4/ppmKLA==
+"@comunica/actor-query-result-serialize-json@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-2.8.2.tgz#9e395999b1c1813c48c07b5f0ebb6808fcaa398a"
+  integrity sha512-NFPEFSibNGAnQbbyY2xjwauCq+DpvakMsDZItIWDKtQ78G9oYUc3u9vsR19sfkBFhNrVUeN/n697QLISRiOdYg==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     rdf-string "^1.6.1"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-rdf@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.6.8.tgz#8a11ea3a1da8a0ca4ac34cabd036376f54c2fb12"
-  integrity sha512-0jPjloCHQDpCmN4tkOs7R/ltwuLG6uKp8R8pZDt4RL4xwNz7eYreAllnTtY7fOxMhtExvy72hE5q6OYN1GLWRg==
+"@comunica/actor-query-result-serialize-rdf@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-2.8.2.tgz#f94a9a3cfc3ace07fa9661b9db453a533562baad"
+  integrity sha512-mhhTW6ksmj5MYxaNMAEarsP3sFlCJ3qci8hgqAIW/nr8aXsZua+6xIcgyJb42Go3UhOTCJYwyQJCXAPm8s6d5g==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/bus-rdf-serialize" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/actor-query-result-serialize-simple@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.6.8.tgz#4cf5f16a453db09329ddfbcc6e5e0550cf77605c"
-  integrity sha512-BTFZNuS7LcKPDZzPWR70XjZycPIkvCEtjiLNW5Zve+V2rbxawCzmDjzzjwpQREypWjlEPbwK42CN5b7uIuqkig==
+"@comunica/actor-query-result-serialize-simple@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-2.8.2.tgz#66321fd65a3f9e17fbeb3985a3f5d205b421aa3a"
+  integrity sha512-EIzCuH7iOkKT2etXcW2nV7UoX6LBLISsXksGb5YnCewS6LrTjzud9ZjBANjdAZZGneHkjp/vuS3Inkx6jJjLIQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    rdf-string "^1.6.3"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-csv@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.6.8.tgz#184e9f6481f01ecd60ec25db74ab34559889a0b2"
-  integrity sha512-oLsNOH+iJJR6KcVmG4oIkC8eYJ7zXaKFAjcIl40KOSc8rgrMfw2jhtCSimgnz944VkrAiGzXA41ZFTe80BxB2Q==
+"@comunica/actor-query-result-serialize-sparql-csv@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-2.8.2.tgz#21e90c28692d321615bd70b3936efee6796f55d9"
+  integrity sha512-haCiP2Tr8vJsR60ebigW5Pv35aJXtN1c4hckpjIHsyHX0b0Qa08wnb2KNgP0K+MPRbu83siaju7PcPVi1rDHNQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-json@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.6.9.tgz#458b98c2580b923a4e8cb981ecbca0621dbc78ec"
-  integrity sha512-b4xEhtvNoQ0l/GUqfvyvssPubH59NJbiznvjtLNhKj4nXci6BCH6x3nTAbgyvaJ/p0CcX8RXIq1q4TFquht2bA==
+"@comunica/actor-query-result-serialize-sparql-json@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-2.8.2.tgz#ed371a70b8b29cbd3f76f6af0e1b42bb05661fd5"
+  integrity sha512-XtiSEuzCnmP2IkTlW2pQRQ/ErLZWgPcSw/J/cgS1Bg4RKl5q/njvZv2fhqsY3a79OAgRptMySVLmzcNIW59+qw==
   dependencies:
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-http-invalidate" "^2.6.8"
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-tsv@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.6.8.tgz#9d9088b4ffe5c1ba149fe9ca071213a0360b983e"
-  integrity sha512-TurvRPRktYzv6punDaXvASlRxWy5z+Mcd5apliruY+nx4a3kVYkIP79MOagvYZKBuWwDlqrxvEiz4BsMGpOq1Q==
+"@comunica/actor-query-result-serialize-sparql-tsv@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-2.8.2.tgz#d34fbd0c8ebba0641e831afb782e98c56a9f66c1"
+  integrity sha512-off09bx4VvyKMtkAXmaB+Y0iFqsnBPL8/QDN1kdDeqnJNY9n0fV5XPwB9C1XBZjqAmzcdzS3+Ac9hyOkhr1wrw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-string-ttl "^1.3.2"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-sparql-xml@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.6.8.tgz#66ab7093609fbf74b5e67a56813e0bf8f4aaee0f"
-  integrity sha512-pz04tyvBogXxWUGrku5Ih9ulcMCgCdRIANYMJVO72eF4eElLq0GAW866+SRpcwPecwrGXxt4/B1CNn1jS691qw==
+"@comunica/actor-query-result-serialize-sparql-xml@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-2.8.2.tgz#f6207e8b3df58ddc58cf1f7ad67082e6b1ba74b2"
+  integrity sha512-fNpMstEwEnl7JsLmh9mA5mznuPnfrv3r2vezzmUmTXRFN4IrxjeSQvXY2oSUygQuWqLBoybsGxPxX9VhncHbgA==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-stats@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.6.9.tgz#a63e53fb6bc9370cf834ecf5d5fb27497d6966c5"
-  integrity sha512-rfANxmiQD8xReSU0RkHiV/9O9QLvC/RLl83k6IcGsgGjeK0yHgucEdC/FdXE2duheXTVmlt1CjxqQ5sG+AKE6g==
+"@comunica/actor-query-result-serialize-stats@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-2.8.2.tgz#09e9d948601702ef9c0f73edb9667374def7d372"
+  integrity sha512-DLO5mZ+Y8AVrKpK4W0gERUUM5b++i9GwPUqvLIps9wG+RPNWV4TbthY9PQmdG7WLefJBfHOiUSia6v86BTsk0g==
   dependencies:
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-http-invalidate" "^2.6.8"
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    process "^0.11.10"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-table@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.6.8.tgz#a1405de70dfa8898a17fc3691333582e6f425a76"
-  integrity sha512-r6zfjz3DXrs3FbLg9h3DRUnXrxr/pfwfDFyAI+iDObqB9Q7TbbB8MF9XHBNGLVwNBIDqsRMcONuz+L9nzVFzBQ==
+"@comunica/actor-query-result-serialize-table@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-2.8.2.tgz#7adbff0cd8d08952f5c3ba1cdcb91d474476d071"
+  integrity sha512-IK/LUY055QDqCFBXGLIl8nyd3cVcy3Y9adBYCxRDvAIdHqKZi/wBdZA35RuXfaWAbFRARABtJVJM7b7ekUzKJg==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
+    rdf-string "^1.6.3"
+    rdf-terms "^1.11.0"
     readable-stream "^4.2.0"
 
-"@comunica/actor-query-result-serialize-tree@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.6.8.tgz#b1b12fb384ee627985dcc177da3a981419d60157"
-  integrity sha512-ji01WU546grkS4v7UhU//71a0AsPuT8XvWEtXSNLxqpZc9qITfS4X3XnW026sNPMiIHohqTUrF7HbpuhVS02MQ==
+"@comunica/actor-query-result-serialize-tree@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-2.8.2.tgz#029322cd3981ae5f14f153117655a40c1a0d191f"
+  integrity sha512-oDG+84J6yAV7rnZWzWy9r7RDCjrWnVoBwYuieJBi3TrhQ1p5Ed69Jp5dpvqgeBVC6xANnEoUvPzk0QYLfEvyUA==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-result-serialize" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     readable-stream "^4.2.0"
     sparqljson-to-tree "^3.0.1"
 
-"@comunica/actor-rdf-join-entries-sort-cardinality@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.6.8.tgz#1c4a84d71eda530cea7b262db54787038fa77f2d"
-  integrity sha512-P6NT2QHmZm4wy/63CL8aAP83+e0ym2PI+EfxxoEHMEU7H2O3uPKdDUsD26iIfD9b/LSRJIydSMp+JJ76g2X0Kg==
+"@comunica/actor-rdf-join-entries-sort-cardinality@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-2.8.2.tgz#4f4dbb84f4dee0b8f7bdf8050fecef0b04c28af6"
+  integrity sha512-zQiGXcmu9obRxa0H1zEdEQ3oIjnnw9v0GZtafNSoYc/0GJxMJvo9phmAdAsftB6Yf9SvpqKIcbPhMIS1QiXD5A==
   dependencies:
-    "@comunica/bus-rdf-join-entries-sort" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-join-entries-sort" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-join-inner-hash@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.6.8.tgz#8cef99eeb37aab4a7e3077a2bab83405cc6ab194"
-  integrity sha512-ddGBGo4Jqb/uf1wMPNfIV9cJ8hR0L0gY74NVv4auJRBnueEkYENFC8UlGSExr/MkSNrPC/BrQ3t1PjIM65q+zA==
+"@comunica/actor-rdf-join-inner-hash@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-2.9.0.tgz#21c097b66cd089de2ade6e213cd71cd88d4bc500"
+  integrity sha512-LuTfAaua8w+TdtYx47yz3RO8hEGj/b6asiqxmPhlsT8eRf7/fr4YCvKUqYGzv0B88Zj9jMawOWjRWhL2lqt+Ng==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-inner-multi-bind@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.6.8.tgz#9659c11c4e533480a0ed18b13a62e547583ee764"
-  integrity sha512-J8ddecK4dgrpwi738q1dzVgjU9+6GkOWeN2XetklZwRMzF6llCfxae11560eYjN+KhORZ4Q4ptk1iPfGGz+tFg==
+"@comunica/actor-rdf-join-inner-multi-bind@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-2.9.0.tgz#b3f4e84e8fd1aec8a3bb3e2753871b65957669de"
+  integrity sha512-BXetAide8cRJtdmluyoG+hPeIfo4lq+RDRBgMCtYgCbQVMeMcA6XexrA3azoqH+67z3asye7ZSkUh7BanM2nWw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/bus-rdf-join-entries-sort" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/bus-rdf-join-entries-sort" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-join-inner-multi-empty@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.6.8.tgz#06c3b4ff98e4bc52c3334427b71049b5325294a3"
-  integrity sha512-27e7EsYy8FfnC1q8prcldBxVCWZsTaTlNzNTm0/hT8x+40KtvAg+dKoQhmeeLW9J8ns259B/YYt2dZS9Xk8pVw==
+"@comunica/actor-rdf-join-inner-multi-empty@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-2.9.0.tgz#4ac0c595a10445111cc1b3de0a09cd55597753c6"
+  integrity sha512-L7IMYD3WRjaDdN5DP2zIDPScVkLWsY+7oTYxlzT+fmZXakPkbxse4MUnsZBzBLCRYLhq4wN5Dd87CSjmzqqOeQ==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    asynciterator "^3.8.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    asynciterator "^3.8.1"
 
-"@comunica/actor-rdf-join-inner-multi-smallest@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.6.8.tgz#877a15b60f30a1efa687bb4c0dd62ad524964c75"
-  integrity sha512-mf6ySQ6gJZ4FBJNwXRIlbo45qXzMJvrg1I2WUyC586T5ZJXU0p5903CcEuKz+hgeXUXcoX3Qc/QeN2Orv3QSaw==
+"@comunica/actor-rdf-join-inner-multi-smallest@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-2.9.0.tgz#c1a6e7c00f5cf6bd79be4b2827079e243c913d9f"
+  integrity sha512-gqa4ATeXAhG7HPq73kUs/swBZ7sM+3bJyU/J6ppwQXEFnG6NDSSuyD+0DxxT9erb9K1lTLCHfHTH3W7/RQW1nA==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/bus-rdf-join-entries-sort" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/bus-rdf-join-entries-sort" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-join-inner-nestedloop@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.6.8.tgz#b9d54b1aae5f0e85a9c6a6654c6c934b1a43f146"
-  integrity sha512-JRWmfIkTGk2xDsGG+lzxAv4EQY1YRc+OT7JOtSdddgnB8tJj5esGFF5iwUSEZJt1ykuVmmVbfc193XhRYJ6m7Q==
+"@comunica/actor-rdf-join-inner-nestedloop@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-2.9.0.tgz#510b15386e2e5404ccba472be55905ec6586a36a"
+  integrity sha512-7Om/0MXIw0+D6TOw9PUMVOxj6Owbpj2S+hlyKVDHOQxhr+T6Mh6KcfTfvYVviLoYikC4DFgGHPCzo/6jM6szxw==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-inner-none@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.6.8.tgz#f71f902cb8d1709fd1a42a0229a0b36b3a02baa7"
-  integrity sha512-diQfdu8xYrvEtT1SwkjNDLECCN4ph32TURyBvmfIaOZNysA167vV/JlFtjYKHQZ4aH8KieYntgB3krdvaqFT6g==
+"@comunica/actor-rdf-join-inner-none@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-2.9.0.tgz#68a309b51be0e8e9b8a75fafd7ab478205789f8c"
+  integrity sha512-xZSeJ9Y6x2L9nd+Ygy8VykArM7lGE1PnffH6WHHah2nepTm+o4lwsZiQGs9bTefwqX7Wj+xP3jR9klujQTLzlA==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    asynciterator "^3.8.0"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    asynciterator "^3.8.1"
 
-"@comunica/actor-rdf-join-inner-single@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.6.8.tgz#b4e7b1f131976bd179b0f10538f896d36fd7134a"
-  integrity sha512-3dNiL2cS1ix1KDfaqtMLQngMKOfkJ95CmLJOx3W5CEdY2ZiayJJPJguhkQKtV8b3sdRaOx2lyvZpYpUTRYqwlg==
+"@comunica/actor-rdf-join-inner-single@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-2.9.0.tgz#e9f2fa203860cdea423cdf3620a3f983d22a602e"
+  integrity sha512-vIDNkK6xBgVsj+Rq3wqyJPmSHZ8SFuZ6oS1wCYFcrkFDJNV20ORGPKvjUWRoqs8ci1bzyri+EOOaEvWDZV9yfQ==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
 
-"@comunica/actor-rdf-join-inner-symmetrichash@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.6.8.tgz#09933d967ebaea0d33c88d607d0d8820df3c9867"
-  integrity sha512-NR4aVxiY2qZG/HatN558OCtrBHzNSzPDlYtrUGXAsgjmQXWQV/W5alvV+UjN+IXZCorAXuCeleHILAglpQT1BQ==
+"@comunica/actor-rdf-join-inner-symmetrichash@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-2.9.0.tgz#6cfe26e5ca7d0b74a3cba61db03d19f20a9a3eca"
+  integrity sha512-apECfM9fZSLDKSPOr/GNYQD7xlW49BUpz1LUzvhXOUSLEz4VSulucb8k8Lh1hVofZBKaJIf0tbNNGY2wL1Xk2A==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-minus-hash-undef@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.6.8.tgz#b736a3a45e873c90a865f4953681610b298b7cb9"
-  integrity sha512-Mm7zCeMbnexo734SWG9nB+coX8f2V7cdatV10ar/eoTnXqgArH27VS4lbIzFVSfuv+8eR3+CyeBNu0FY2D5DVQ==
+"@comunica/actor-rdf-join-minus-hash-undef@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash-undef/-/actor-rdf-join-minus-hash-undef-2.9.0.tgz#829560517d1d8690d3d24b28dd8ffc86c6672034"
+  integrity sha512-txJfFlmFi2+a7FKoHGtW7b4XUqFbqBitTBDbnRf5qiSmf1t/zMXgOJsMUYc3G7Xl0qI2s+BBwUYDid+M4LdZqw==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-string "^1.6.1"
 
-"@comunica/actor-rdf-join-minus-hash@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.6.8.tgz#34bee807faf42bee944f3c75e73f3b9cd68dad0b"
-  integrity sha512-UPqjtlXzQJIt0F/VLDttxdROpt8/7tt9VBhV0NCNmEheiiInfo90OSZjLXkO/+blU6GFUw1lrJ+eAwhaUPYNsw==
+"@comunica/actor-rdf-join-minus-hash@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-2.9.0.tgz#d52bdbf430d6c90f101ad51a8ab613b06eef6700"
+  integrity sha512-twhwuvIRm32kzQUPVGa2I2kgazsqUVjAljC32SIFo20vPfgop/C2q9hlXKpHbw1n2aRBYngfdizAK+jim5sl+Q==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/actor-rdf-join-optional-bind@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.6.8.tgz#cdd3f477c633c516aa0f4b2b503960a7d041405e"
-  integrity sha512-v3pTZVebH23qDMQIQULI8MbI03CnuYfPR2eT2+MzHe7fULnx0D0FrzKzwLaY7MSAiVlpD+/K5aqVYBkoUeV5oQ==
+"@comunica/actor-rdf-join-optional-bind@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-2.9.0.tgz#b50e60c23316a6c6061b94703cc5f6fce88275b1"
+  integrity sha512-P4TIfHrf9UNd97hD4CT8gmrXQSe2XL6gwJ5yBh947oJEeO8coi3uj9GvRq5vaUN2Cb/a31jbmBFpWC10f8PSXA==
   dependencies:
-    "@comunica/actor-rdf-join-inner-multi-bind" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^2.9.0"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-join-optional-nestedloop@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.6.8.tgz#fa28ca45a084d5fea212d2c4f242e4e26ec94671"
-  integrity sha512-bhDjjuET3cUaBwVoVFuu6bN1+5fgALqDTbHrNC+BDjd/IvWbuRVg0/w/EN7tvuB8jz6WcUr4CsuzAhZu9xPPCw==
+"@comunica/actor-rdf-join-optional-nestedloop@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-2.9.0.tgz#e5ca98f2777dfa1ee8e61f049e81aca57352fd57"
+  integrity sha512-chnzNSjUZqIsmBCkU4+Joxc0ZZDS3vM5SCpNlpVrdgVNAjkxmFg27JZjR6MGFoDIub1DG8K5/saQ/cLjpgDDMg==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     asyncjoin "^1.1.1"
 
-"@comunica/actor-rdf-join-selectivity-variable-counting@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.6.8.tgz#123fd913f69aaeb224617ef56eb144a4a22b3aab"
-  integrity sha512-RIB0ARyCdhopllo8suK/mygVcslfS7PrFVfBcAPldI9x6DfcQjGY4JahVIKdSvFJ8sAKzZwlUlcBSp/f5GnHdA==
+"@comunica/actor-rdf-join-selectivity-variable-counting@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-2.8.2.tgz#1f5db2f416484c3c974b2aed79625e45d516ea45"
+  integrity sha512-NGUcIMpqvSTARJfhLDmiRDd4WY3dEAv4jYga1zB/4tJ+DnQhgDIrbKGjneTbv65taDQ7MTzeNfbhCNv8Luc63Q==
   dependencies:
-    "@comunica/bus-rdf-join-selectivity" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/mediatortype-accuracy" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/bus-rdf-join-selectivity" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-accuracy" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-metadata-all@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.6.8.tgz#aff06b845d0c1c7feadb0602cb5e03e56f8a821b"
-  integrity sha512-trHNg0EIAJmrzsWQ/YG8YKBLfYV5JFjHc9i/ZPluBvUFaKphCR//asqhtFF6O0dHL6usCRrdOjqDhky1dZzvxA==
+"@comunica/actor-rdf-metadata-accumulate-cancontainundefs@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cancontainundefs/-/actor-rdf-metadata-accumulate-cancontainundefs-2.8.2.tgz#e6d4c6589807264f9ef8a5844abd5a9ee40277c0"
+  integrity sha512-tQTP+496kavL1uEfSksXhOrmzcYVjlsXpCnsOwO5l7niW3UO1YAw+T8cG0qVFmgneNk/jRH+JZm1Q0QdoqSo/Q==
   dependencies:
-    "@comunica/bus-rdf-metadata" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-accumulate-cardinality@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-2.8.2.tgz#db5e84bab2251a45159edf5f8c1ea07af2602db8"
+  integrity sha512-5wrc2F/iCvfQq8quHUnXQyEDlNRjIwNPVqYkiXW9Ux85UZy8ytpSvqd+qZ/7XLL/U7Xr5+reBygQmu9+J3iIug==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-accumulate-pagesize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-2.8.2.tgz#b489374193f5da29a9579749fbf4aaa39c6d8b0a"
+  integrity sha512-W6O2adLYU400x1limh7U7/Q8sLA6yZiAPGie8mu/W6Kg/1ht/kPUtcIeCU70mxOQqSYMEfmVOl3uL/pIusWkLw==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-accumulate-requesttime@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-2.8.2.tgz#892e7831658f3a4959fb4de35ec9b387d73c7205"
+  integrity sha512-IUZqSEFZE1hHWAXkc1MFoosbbCmDMyGyICP7AKsRKDyEo5f09UEXbL9M6aIslx5oSBzEwGRYcPrdTOOZi/+eqw==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/actor-rdf-metadata-all@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-2.8.2.tgz#af8e307ab938cbf895d871a27e85edd195e8d25f"
+  integrity sha512-gpQtNeB7Y65CRMMWPU7ybKfm1ETh1O9Q576pKaRwhfN1OdeTcK99bMRPCwu2FMZq5fpXgpFEz6+pNPod+NMovw==
+  dependencies:
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-metadata-extract-allow-http-methods@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.6.8.tgz#1fc4ba7f8c9e8c2ea6112c9b9cf47a9188a81d2e"
-  integrity sha512-stnd45XTPoVEcUyZkZcQ6j2VzlKOe6tDw4v/VJpNhvBxsrRtUwzpnc8bBAudhhwg4lRwDxSNJnT8TlTs4g6txA==
+"@comunica/actor-rdf-metadata-extract-allow-http-methods@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-2.8.2.tgz#3f3830ce7244d231a697e4f6306d73240d1642fc"
+  integrity sha512-blySkab/iCI6OZ5dXSycUBO2Og8i9FSPOfz0d67ELeFk01MULocUHNRPU9IvBVLMOJgt9SbY6xISsnNDYqNgjg==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-hydra-controls@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.6.8.tgz#71aaa237948e90cd4aabba8b1f651f67c7159c57"
-  integrity sha512-StQFpGaMZWmb7Gbn8Xx9g602U/fDfyzw6ywF8jsmv3cqU8ZSk2nUZ/Q66WSF0EEgzFk0QSse83lhTnzvdzE1/g==
+"@comunica/actor-rdf-metadata-extract-hydra-controls@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-2.8.2.tgz#b768eff4c728f9207065464212761c8daadefcc8"
+  integrity sha512-cID6mNBpyvrA+kSMxxHjX/bi4IYtqWjaaitzSHaRihQeBmwpX0UhjapRm8qcLdIOhTHzOUgSqayml6lOpFAuBQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
     "@types/uritemplate" "^0.3.4"
     uritemplate "0.3.4"
 
-"@comunica/actor-rdf-metadata-extract-hydra-count@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.6.8.tgz#2f75d441a0469c93ed425243667ea79f6baa774f"
-  integrity sha512-zq5Of5u/gWNSmDd85W7wmvpVFAqWbPyyoqGT2R1cM4amwU4zLN8cblEJvXtnqJghmmq9DwDW5y84l7yGkwcArA==
+"@comunica/actor-rdf-metadata-extract-hydra-count@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-2.8.2.tgz#5ad15b78ff2ef45e55c541f6836a546b6e338929"
+  integrity sha512-c/+zAzmEaraMX2HsK0E1pEFciioT18UKAGk6ZNT+lJ1q86LMx+Ky5RFH8FtvCB8dYdc7K6AuLWsRiIvVzw/K4g==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-hydra-pagesize@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.6.8.tgz#82f20d5b228a35fb7f3df11c7e990c9db850568a"
-  integrity sha512-HiaWJeN9jKDyQ7248I4k9RU+MhWnS7rO9NNQkHxthuex+q8Hw1y+G5UugnQiKj5aB4vNr2G5lzZm4jQsOBJbBQ==
+"@comunica/actor-rdf-metadata-extract-hydra-pagesize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-2.8.2.tgz#d81b37085d507da6a66d272a557d818fa5a823e0"
+  integrity sha512-hYkc5UTcnBFkbGgfx261amIqnlLTg8rhky74UjY5h6eSlXRCA/viAQuZhuK4jmguQsL4qfv0tAG+ASKC0ZEyGQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-patch-sparql-update@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.6.8.tgz#a71b00eac1f250ed5d407e82b5fc39fca5369a9f"
-  integrity sha512-LPvofCeshIz84LfsWNBLTH+jIq4LUqYO1dfELEvdngOTByxdEK/nK9DRZCj8DjzjlzO1OC1L3dz2CBG39DesKw==
+"@comunica/actor-rdf-metadata-extract-patch-sparql-update@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-2.8.2.tgz#e9abadaf5a733580dcf199f3e37797211d8e165b"
+  integrity sha512-UHVqYWGBOkVaE0gMvoj2kHIj4k2tSOPM4SnVX0y0x1vw5dpJk+NEwohbEPhYK70WUAzqDxPFHE2pPa8eeClE9g==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-put-accepted@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.6.8.tgz#5a6796306f3619e38f7241c3be2520083c05d244"
-  integrity sha512-mgQxvcQSO1XVPLCycOxUsAb/cyu/MoG1frNud5aYSqSA21loRpFP5Fej0B6ThGkLUgnF29xUtGEQu0YKcI3W3g==
+"@comunica/actor-rdf-metadata-extract-put-accepted@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-2.8.2.tgz#b6c34618562e33c40d5512b91293284a6feec6a5"
+  integrity sha512-nOkk6WC4aRNq7JpfiwYTOfZeLCKfe5sJgfG2yLFpeea8lUkwQBUTn6UM6ZkMy78euIkIpMuu19DuxmMdFwAWDA==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-request-time@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.6.8.tgz#64e790354628f6277e8171ec40de46ddbb32f175"
-  integrity sha512-gH6LApriHYaBfYCVkOVR2JsKFwrsSiU/nY2T40p8DA7u2UDQA+to3yd069hYHCjQym6/hJXj8+dq0/3TxfOQDA==
+"@comunica/actor-rdf-metadata-extract-request-time@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-2.8.2.tgz#4218c54ed22170370f03cb23a27090704902ade1"
+  integrity sha512-shluvPWbNXBovQd837+JT7EwAWwQTbnYW1h1DgbH7hI3RjNj+0rSRFUAGvXFe1wSC3xno/sHMAxjVFJ5CzKl8A==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-metadata-extract-sparql-service@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.6.8.tgz#8d8654dea76e308c31425626a9b990878e05a116"
-  integrity sha512-suT5J8+fyPTNJEk3n1P6eoHUcBICCEEs84GPrv+fiKrzDiR48wGny3PVNCLRZrt62CEkTknA3oPSxfgY4agyvg==
+"@comunica/actor-rdf-metadata-extract-sparql-service@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-2.8.2.tgz#e025ea7e3aba3665311925704ddb45874a2b0ec3"
+  integrity sha512-uWOMyccUI2qX/fE70pgMrb2cJDIDc75LPe3UfCRodHaIeIW+2kYcQZDDR/f43EtrISbJrgLu4MMZVeislroyuA==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-metadata-primary-topic@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.6.8.tgz#5d3f83ff777c2ea74e4792ec2e844f59c401ac74"
-  integrity sha512-Bj56KSIF6FG5C1wwMFel57F5wr5xoDZkvVAEHue0Q3sCT6pQD2vRk8l76NC8tSJ4t5+RqwEFKU0Tcp7AXXMhNQ==
+"@comunica/actor-rdf-metadata-primary-topic@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-2.8.2.tgz#36c99dffeffb054e10159e1c8a97ec642d3fc59c"
+  integrity sha512-Wq4Z+03kQv9eaukTS9tW7FloZd7ggkbCgYUyKvevVKAmHQiZmX/YamxCsvuIPQBNUQedpUFCXhitD3uLZ4GwJg==
   dependencies:
-    "@comunica/bus-rdf-metadata" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-parse-html-microdata@^2.0.1", "@comunica/actor-rdf-parse-html-microdata@^2.6.8":
+"@comunica/actor-rdf-parse-html-microdata@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.6.8.tgz#1439f0c25370357d26b6bda1a746d72261bd65d8"
   integrity sha512-lDR1kHX0bTOjlOQBxUXBy/Csch2exQg/uzn3J3VOrOEdi6PLQl2YD3Knv1j7/TLoWE6KyU5vMPVqANlERXKB/Q==
@@ -1326,7 +1406,16 @@
     "@comunica/core" "^2.6.8"
     microdata-rdf-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-rdfa@^2.0.1", "@comunica/actor-rdf-parse-html-rdfa@^2.6.8":
+"@comunica/actor-rdf-parse-html-microdata@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-2.8.2.tgz#df447b1bcfc1641d1434424ec395267f6731241e"
+  integrity sha512-vJOjT0xNpUpwqf46oZoXj4hjEK5FrstyjHeuVe1nJruPCE2QMDIdt/wcc9SP2T/Px5uvEjDUgEoxAEOPWkADAQ==
+  dependencies:
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    microdata-rdf-streaming-parser "^2.0.1"
+
+"@comunica/actor-rdf-parse-html-rdfa@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.6.8.tgz#fa8be6b4159ef1c0b672b6398956b1fbf4864033"
   integrity sha512-uavBJ8NzHBMsE9xbUy8EeDEd384DyndHIh0jLgCsmLawSS75kdBp/m1iydMRoWqv12NZFkhtmPQCsC0gseXDAw==
@@ -1335,7 +1424,16 @@
     "@comunica/core" "^2.6.8"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-script@^2.0.1", "@comunica/actor-rdf-parse-html-script@^2.6.8":
+"@comunica/actor-rdf-parse-html-rdfa@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.8.2.tgz#37bee07c35b957994eec35f7178c263d7c3247b4"
+  integrity sha512-Ipe5NWHZJsnGs8KZE1GbNIRIV5DyF+IOt4BR8z4QmQu1IjzkE2zFG/tT7hI4ZQ7jYjMwkW3xcfsK4FJp+MnhQQ==
+  dependencies:
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    rdfa-streaming-parser "^2.0.1"
+
+"@comunica/actor-rdf-parse-html-script@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.6.8.tgz#ade79da4a04f4b6218231ec28de5316ae6ddb070"
   integrity sha512-FC4fTbSya7HHLDWzMlR3gST4bhu6R0Utnv0YVeXc8OssOYpqWqSSGpSWP+kvEcJif6vedIblKuV49ixbL6yxEw==
@@ -1349,7 +1447,21 @@
     readable-stream "^4.2.0"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-parse-html@^2.0.1", "@comunica/actor-rdf-parse-html@^2.6.8":
+"@comunica/actor-rdf-parse-html-script@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-2.8.2.tgz#23c726a874c11eab204da16a092b9f63f4c19512"
+  integrity sha512-4Y87tzHJREywzjCbS/A7lwPtrFXIdb6pEnyWK/UROsj8nw8M7UacKog6hyB0iyeZGPM43S9x0RC/u5RWA9PHrw==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    readable-stream "^4.2.0"
+    relative-to-absolute-iri "^1.0.7"
+
+"@comunica/actor-rdf-parse-html@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.6.8.tgz#ffca4e0c3722c43d68c80ec623e4f48c7f92245f"
   integrity sha512-LV/7Wth/Gw35fCoBul/jX9KchhGWn+K41Y+6SsEENJYStvJAANDxSuSckW9vqHoz54kx5OslbNqVCFh59PZMQQ==
@@ -1362,7 +1474,20 @@
     htmlparser2 "^8.0.1"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-parse-jsonld@^2.0.1", "@comunica/actor-rdf-parse-jsonld@^2.6.9":
+"@comunica/actor-rdf-parse-html@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-2.8.2.tgz#77a22e973465367386a615a2077e3211bfaf631d"
+  integrity sha512-SV7iBGETX8igGyB84TVxM/2ylvugDAfDNgxkZPxuEjJfi65YHSt/pqnXPYYcuZ5QCO59gjBVMoeSIdNvmCHoOA==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/bus-rdf-parse-html" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    htmlparser2 "^9.0.0"
+    readable-stream "^4.2.0"
+
+"@comunica/actor-rdf-parse-jsonld@^2.0.1":
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.6.9.tgz#48a43e34d4efd664233f128e25e10460bf3c1141"
   integrity sha512-Xrn/btRySgMV7QmrAs/a6IMYo+ujh0Pn09TKfxLFa7xCQXozwRZI4dXnpaoCTBxc8xPZfVS3WrrmzRop2QjOoA==
@@ -1376,7 +1501,21 @@
     jsonld-streaming-parser "^3.0.1"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-n3@^2.0.1", "@comunica/actor-rdf-parse-n3@^2.6.8":
+"@comunica/actor-rdf-parse-jsonld@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-2.8.2.tgz#94d3e89fa3f733eb3f067bac1abb0a00d7fb34c5"
+  integrity sha512-6H5HmiMujyISzxMAGWDjpMjWb1VD/GYw7Jzx6GWy6M9tjxcvkJRlgUl0dXOhIOlh/0LohrV18bKnA8uUcILzZw==
+  dependencies:
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    jsonld-context-parser "^2.2.2"
+    jsonld-streaming-parser "^3.0.1"
+    stream-to-string "^1.2.0"
+
+"@comunica/actor-rdf-parse-n3@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.6.8.tgz#a9d54b4fdf625bbb7628fdecc623149dd3e39d27"
   integrity sha512-D7+bjo9qV6dJMf5IjQfWKCtoVFvUG37EPJAXIX9f950JJmcWrc6JFnYMpFGZWDQOBIAxTepBszD5QkTM54JNfw==
@@ -1385,7 +1524,16 @@
     "@comunica/types" "^2.6.8"
     n3 "^1.16.3"
 
-"@comunica/actor-rdf-parse-rdfxml@^2.0.1", "@comunica/actor-rdf-parse-rdfxml@^2.6.8":
+"@comunica/actor-rdf-parse-n3@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.8.2.tgz#bc607db929bfbae18e1edd14db0377bb5916f39b"
+  integrity sha512-vNbIA8MsZ4AGUTdxm1wcccjPyH4moMV2gGH3ZLhf2c7/zvVHbRiVcD7FB3ELU0yHUD9o5H9UBSwsmLMWQTSxcA==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    n3 "^1.17.0"
+
+"@comunica/actor-rdf-parse-rdfxml@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.6.8.tgz#ab4c947324cc96253c980614607cbb59c95ff7e9"
   integrity sha512-aBHIf+OGt3REgkCcf9+u8Ywo0FAj/k9VTNgrTm6K/TZEmSpzdlD+gdFnBOH9bw2yN4otYt7bkH4siaIUjTunMA==
@@ -1394,7 +1542,16 @@
     "@comunica/types" "^2.6.8"
     rdfxml-streaming-parser "^2.2.1"
 
-"@comunica/actor-rdf-parse-shaclc@^2.6.2", "@comunica/actor-rdf-parse-shaclc@^2.6.8":
+"@comunica/actor-rdf-parse-rdfxml@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-2.8.2.tgz#3576c968f5ce3f3ea0fe1bd951f7bb3d4544ed0d"
+  integrity sha512-5SoYBhrPicqHQKUTK20mYZqILctrIcxjk9R+tdhlAHzWOIT3Usmx87t2/5V8Tf/mr6ld9snQIaYS19QtU8MQYg==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    rdfxml-streaming-parser "^2.2.3"
+
+"@comunica/actor-rdf-parse-shaclc@^2.6.2":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.6.8.tgz#dbeed4c2a9e6b6677ee2e7f1b49d4e1a5423a025"
   integrity sha512-hGM3eoCqyZuwAg9SLDdJjbFo79YHgADKDP+LjJnlxtrwt3vWTy8NLcodeg7NrvlbMS5UDadtK51402VBAiumCw==
@@ -1407,7 +1564,20 @@
     shaclc-parse "^1.3.0"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-xml-rdfa@^2.0.1", "@comunica/actor-rdf-parse-xml-rdfa@^2.6.8":
+"@comunica/actor-rdf-parse-shaclc@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-2.8.2.tgz#c477544aaae5209e0a2c6ad2ddc64f11698d0b34"
+  integrity sha512-O27yF5qi1wQ9KhHrdLpZ3+l6w8FuJiWnFvMWVlsGbs+9xCu5kC/LacAemhzfXFAXPHQ9siNjznNZ5g/ZV/cIgw==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
+    readable-stream "^4.2.0"
+    shaclc-parse "^1.4.0"
+    stream-to-string "^1.2.0"
+
+"@comunica/actor-rdf-parse-xml-rdfa@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.6.8.tgz#bfbf805ea0199d59f7917eb0136b7a2d894841fe"
   integrity sha512-enBcz9aCcpdgGX97zgjo2SbTLBgHuJ/mReF2vr7ipT/+3+Sjw40Vi56+SY5SeeU5NOeNvnxAN5O31CPIc2+yUg==
@@ -1416,294 +1586,310 @@
     "@comunica/types" "^2.6.8"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-resolve-hypermedia-links-next@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.6.8.tgz#d76e807c243a78578849334285c2a277dd86f01f"
-  integrity sha512-rTGjQnzsoyqxGz889LmuytvIpnFEvCWIBW89LdtzCB+bp+8KZz0XWn5hcHwt07b8Ky93FsazosTGHpd7FwQf3Q==
+"@comunica/actor-rdf-parse-xml-rdfa@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.8.2.tgz#99902af8794f6e98d1d2bf02db5fabb07aedf8a2"
+  integrity sha512-8bGTXpDbUqNowoSmLXapC/4blKQHWicVoV5NfdTcCrB0Nxs+oHa3I5DJMShQ6EBwCWVaScYcCcGFWIvE2tQPyA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.6.8.tgz#802bea6367f887b1f4c10e56a0423ad8becf163a"
-  integrity sha512-++z3E/yJ5GRTtb7K2Y4Sx0IXb6jn9v+SYEDyLV7zuVnNHZ9A5lT0OVFPA0NF3XTF6VH4ygL6pEkQot//cXvmuQ==
+"@comunica/actor-rdf-resolve-hypermedia-links-next@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-2.8.2.tgz#3959fcf9e5b544ca3c372d1b080adcccd0e9480a"
+  integrity sha512-bHNpHoBoJgzaHgpTLZ22VrVs4fWLbA9PcNOQau1Po2yHB9FUq27n7Hg3Tw049CipnFu8cFcBIU74kNFJcwoWzA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.6.8"
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-resolve-hypermedia-none@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.6.8.tgz#db511b31e2ff731416716464d14042c0f3699db4"
-  integrity sha512-sUhCSoLzM9qxyquQ6EsJjYn6iRpy3fj4sX0XsveUmnNCRuFH/QQlVrBl8J4y5oB0BUyflUpa2N3VNBzYJWUNFA==
+"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-2.8.2.tgz#9bd5dd8034f47637947ca214c411caa9f6b8322a"
+  integrity sha512-S8DfXtVC9T/T8vlIjpAPjTfz05k3pojfZtb/5H6xYDUml3dv1xJbaj7BFCzAm83+pnZlbQMrcacVQJZgG0zE7g==
   dependencies:
-    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.6.8"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.6.8"
-    rdf-store-stream "^1.3.1"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.8.2"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/actor-rdf-resolve-hypermedia-qpf@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.6.8.tgz#4ff577a7a7e5aecbfb687601d353b3001f625920"
-  integrity sha512-l6t1G3iCqlaohA0Ab4RNKEkHt1pmD+BOKSdAeFZC7v8GNRYgDVLyoRKpuP5Y3FwIeFOXtTdOyHSuKKF4qC5/eQ==
+"@comunica/actor-rdf-resolve-hypermedia-none@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-none/-/actor-rdf-resolve-hypermedia-none-2.8.2.tgz#a002b5b3518243596f65a10a9842e075b6f5787c"
+  integrity sha512-jJ37VyGSQqUKFvrzEJpWmNMeEfoBo9XXzFpSaUsca7EG1JTdqOByIf/mNO+LW9R/zs2s/28Q4C1P/kNbZc7UQQ==
   dependencies:
-    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.6.8"
-    "@comunica/bus-dereference-rdf" "^2.6.8"
-    "@comunica/bus-rdf-metadata" "^2.6.8"
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    rdf-store-stream "^2.0.0"
+
+"@comunica/actor-rdf-resolve-hypermedia-qpf@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-2.8.2.tgz#fa8521a923e041814973f5272444e047652d9733"
+  integrity sha512-RTZpu24oKIIlgZ8V/h76/1CaKZMojnkKCrPbrZz/H22TkCvAEhHL4QHblOExePOPM/Rd9jgpkDFV2FBPp3cVrA==
+  dependencies:
+    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.8.2"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
-    rdf-terms "^1.9.1"
+    rdf-terms "^1.11.0"
 
-"@comunica/actor-rdf-resolve-hypermedia-sparql@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.6.9.tgz#30dc969f1b6d6c032e8c2d31b17dbf89934daa2b"
-  integrity sha512-EfkJaKLM8CCRx26Wd98e6qlL9vKqq405bj6g2seuVWDmWg5UoU9ZiXkXY26+c+LB/pupQdaGZYGMXFy0CtBWiQ==
+"@comunica/actor-rdf-resolve-hypermedia-sparql@^2.8.3":
+  version "2.8.3"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-sparql/-/actor-rdf-resolve-hypermedia-sparql-2.8.3.tgz#0c7ae17adb46515a0f25fe2e840c0290009dfdf3"
+  integrity sha512-BWoD/wSnmDQou9KyrjbVH4C8t6VYRLL1Q4w+7KRWieu+qEtQTzeS5rPg1z5vS2EZf7Al1D3lc1/hsHn3LShCvA==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    fetch-sparql-endpoint "^3.1.1"
+    asynciterator "^3.8.1"
+    fetch-sparql-endpoint "^4.0.0"
+    lru-cache "^10.0.0"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-federated@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.6.8.tgz#00b6a711996872e0702358e21cdedd079af5ed06"
-  integrity sha512-4ZnJ4WY+DCf7S20U8P4m3w6rwdOgbhziF6bI9njSoAJYRgxQVvNSvYNi2pAARjlwBNp4VvvaCsEbizwyxJGwqw==
+"@comunica/actor-rdf-resolve-quad-pattern-federated@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-2.9.0.tgz#87d67c4df84f4b452d5faacc6fd7fbf3070a556e"
+  integrity sha512-rRPCviH1sQuG8KoUVlZ4XV4YCeKpSNq12umHjdTg5FWGbe4XmnY5MEOCjYpg8ESNBWFEYXGlpwGf3tIDI0Uc1Q==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/data-factory" "^2.5.1"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/data-factory" "^2.7.0"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
-    rdf-terms "^1.9.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-hypermedia@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.6.9.tgz#5e11382912a7db948b16709968f9cd628cc972bd"
-  integrity sha512-mhlhiSNdP2wKM7jbS1cAXjOZODXE31Clx1gzHDS0EfQXblW777ZJmIAaSrMZuf/jkqW35k9g8I9F388y/+YRrA==
+"@comunica/actor-rdf-resolve-quad-pattern-hypermedia@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-2.9.0.tgz#b833ceb73031a6c2a58649735182c8338c05b877"
+  integrity sha512-IBwwp0NdMEBhE0gtRJ/v+TSzTBw/GoApRZJeFdrDR6S25n8UiD/UCjvYCKvEAUQQXXniV0IcPDKCYEflkX9uIw==
   dependencies:
-    "@comunica/bus-dereference-rdf" "^2.6.8"
-    "@comunica/bus-http-invalidate" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-metadata" "^2.6.8"
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/bus-rdf-resolve-hypermedia" "^2.6.8"
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.6.8"
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/bus-rdf-metadata-accumulate" "^2.8.2"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    "@types/lru-cache" "^7.0.0"
-    asynciterator "^3.8.0"
-    lru-cache "^7.0.0"
-    rdf-streaming-store "^1.0.2"
+    asynciterator "^3.8.1"
+    lru-cache "^10.0.0"
+    rdf-data-factory "^1.1.2"
+    rdf-streaming-store "^1.1.0"
     readable-stream "^4.2.0"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.6.8.tgz#f05a22d771c0d2f2b96ba85af4a6a0a5c9dfb654"
-  integrity sha512-/wkWYBae4NNpN8NLxVOSM4ldL5vIhIoqmDrHoWmXfCBqAhVgnCN4GqxeU1NYbiGQHI+ZDu8eeNdIAYVdAla+1A==
+"@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source/-/actor-rdf-resolve-quad-pattern-rdfjs-source-2.8.2.tgz#49f09a07c2bd234ed9a2c791dc2977906e0ff626"
+  integrity sha512-J8QAN/fJDn7TWPICDkg30bkqUHtQdrNzvTZt1B8UHKjxMfhdsFgT49yoLtiT8opjs/y1nV069Yhb55xXxRh+bA==
   dependencies:
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
+    rdf-data-factory "^1.1.2"
+    rdf-terms "^1.11.0"
 
-"@comunica/actor-rdf-resolve-quad-pattern-string-source@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.6.8.tgz#6c05a303d28fa3840ce1f12941571a8f75de89b4"
-  integrity sha512-nTvVizieWYdeZec+fuFxpa2jEPJ2R/sCxJ7/fFkLKACEkWlnQWRF312VkFbqa1EVbc+YB5N3sApxiNjV8l4fCA==
+"@comunica/actor-rdf-resolve-quad-pattern-string-source@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-quad-pattern-string-source/-/actor-rdf-resolve-quad-pattern-string-source-2.8.2.tgz#bbf2803d810448fc01fe2d6b9a10e3993dd66709"
+  integrity sha512-n7w5u+xvUVLvx4BPagYfJAMRwgC5pAGB3OMmWZBOix0Wid2MnUduXudyvllIsulgzy4i1o957jLRaDFoyr0pbA==
   dependencies:
-    "@comunica/bus-rdf-parse" "^2.6.8"
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    lru-cache "^7.14.1"
-    rdf-store-stream "^1.3.1"
+    lru-cache "^10.0.0"
+    rdf-store-stream "^2.0.0"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-serialize-jsonld@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.6.8.tgz#377d1c15e620e2245d64bff111a8359f9e76f335"
-  integrity sha512-FIpV3MbZEHagKm0a06dkC6m8q+4zHE6czg2Hs2pqGgB2Sg44UcKl6utmUYvNG9EKyJb2MqdwJqIWmKzHwbtmcQ==
+"@comunica/actor-rdf-serialize-jsonld@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-2.8.2.tgz#111c8e90c37066561042684bb12f10cf948b8203"
+  integrity sha512-PChSSIqoRm7Kml565iiT735hcEdDDlNP9gjE00CSng8ByFf8chjl2E+6fQG0xiQS2Mfi2QgD6tLCEK9+O18PHw==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    jsonld-streaming-serializer "^2.0.1"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    jsonld-streaming-serializer "^2.1.0"
 
-"@comunica/actor-rdf-serialize-n3@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.6.8.tgz#779fcc8cdd8fe3535e3bb4808c2eba50e96c8f7c"
-  integrity sha512-dJDzikFduOhpF0dt4yK1cDrFJbbMK5HELCAhTeCCSjHXp+vPc8fzTCbtJ2st2VxFsn0+tf3D7K5YLVxhDJwZrw==
+"@comunica/actor-rdf-serialize-n3@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-2.8.2.tgz#91c3af69220ae3ab4e04fd9957a80b03425a9f7c"
+  integrity sha512-ZlHdt6DpE5oRU13tlAlO7R14mwP/zGlooSSniUmbuh0vO1t8CjPe7iD1V8kj1KDH7E+aadIp50uc+nirGJKeQA==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    n3 "^1.16.3"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    n3 "^1.17.0"
 
-"@comunica/actor-rdf-serialize-shaclc@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.6.8.tgz#f0ed96040c93da50c34e45ae90de59f7ec18a862"
-  integrity sha512-xNDsa3Ma6AU0bCW5Sm/oEYROKnFEL/v4xAVRqbIrSPZY9dB/eiLcSoEHj8RQtLE51WQ6kFfLj+KDSYLkhFUgrg==
+"@comunica/actor-rdf-serialize-shaclc@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-2.8.2.tgz#1e83a447e9aaae820e7ba0b5870591e41991d6f2"
+  integrity sha512-rySVO0zN9S3B3CjKpbCU/yyIxD+QroaJ509iBbHmriGeV8HfefE427ZpwKjObrd6m3VVLdtyZz2dVW+bUMChXg==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     arrayify-stream "^2.0.1"
     readable-stream "^4.3.0"
     shaclc-write "^1.4.2"
 
-"@comunica/actor-rdf-update-hypermedia-patch-sparql-update@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.6.9.tgz#c3d4243b0ee4c0a27316097023040d6dd9374359"
-  integrity sha512-plcbxi/9uu+1V6e6rav7TlGKi+U2x+wuQ1BoLPx/6hI28gLb2xFJj2moAyyCBNdoCcJc4bwNwoNbhd7vyAljBw==
+"@comunica/actor-rdf-update-hypermedia-patch-sparql-update@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-2.9.0.tgz#c50fddce7a4da9ddb1bfef28278938f7556ba59f"
+  integrity sha512-3nofaOSPuRRNjy5g6N6eI62kPl2X0KYEjDBeKAYG9EExTlm7aUg5bKH9N/6KVfdufLm5+V1zYBz0fJwwbASwuw==
   dependencies:
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-rdf-update-hypermedia" "^2.6.9"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    cross-fetch "^3.1.5"
+    asynciterator "^3.8.1"
+    cross-fetch "^4.0.0"
     rdf-string-ttl "^1.3.2"
     readable-stream "^4.2.0"
 
-"@comunica/actor-rdf-update-hypermedia-put-ldp@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.6.9.tgz#dc1478883daf821949f8522dbb4848b5a5fe1d72"
-  integrity sha512-SqhLJUaKopmFLZErEAnCDnbeFw/Sz8MyTeWUUjlpCfl9lnFilJ8tF2hDuvZTIuyGJ2vVY2P3eg6xdu7wJGwZ3Q==
+"@comunica/actor-rdf-update-hypermedia-put-ldp@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-2.9.0.tgz#9e187dab181ce15e1c0fb5453087eee5635443e6"
+  integrity sha512-393gzoz1OrSEfjNFK8bQOkPXxEkdXRa5CvHrXILEiQQazm8vs6m2MKUaq3v5abmditcVYNwJCca92UtVC1EpFw==
   dependencies:
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-rdf-serialize" "^2.6.8"
-    "@comunica/bus-rdf-update-hypermedia" "^2.6.9"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-serialize" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    cross-fetch "^3.1.5"
+    asynciterator "^3.8.1"
+    cross-fetch "^4.0.0"
 
-"@comunica/actor-rdf-update-hypermedia-sparql@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.6.9.tgz#030008e631a47c93afa963a3cf5cfd528afd113f"
-  integrity sha512-vkqSeRblg3bqmTSh0SQ1+cr6wuuGa8q80t9tGOKM6LEhrYBaHo7JR0MSYxr0mekd53kDUiftawhiX7x8Fhtx6w==
+"@comunica/actor-rdf-update-hypermedia-sparql@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-2.9.0.tgz#74bba7c85d793511acc9b3a96aac209fbdb0ce37"
+  integrity sha512-Vgdcdqkesq5zVMi/k0vdgqRWEaDRYaT3sqyFuxMySXT901dB6N2QQS9iki1OkjfX8h/8SZYsZSnfRy7rLPEyOQ==
   dependencies:
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/bus-rdf-update-hypermedia" "^2.6.9"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    fetch-sparql-endpoint "^3.1.1"
+    asynciterator "^3.8.1"
+    fetch-sparql-endpoint "^4.0.0"
     rdf-string-ttl "^1.3.2"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-update-quads-hypermedia@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.6.9.tgz#52c1c6204f0c4ba1c177c32dbfab37104775e77f"
-  integrity sha512-uViA3NJV04wtFYwFgiyh5mTQhNwZ0SOZpj+aCVprOEYjX8k7FjVQ06ZjG1MY8hoHxtl7Oo9SC0r/LNW67r9P0Q==
+"@comunica/actor-rdf-update-quads-hypermedia@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-2.9.0.tgz#3d1f9b578e23a3bcf9e650c3a8605f8e855f40f9"
+  integrity sha512-u9NLftIL7Lqq9c8hPOvHDVaCxod8uTTPXlhuOd7y6Sb0v0c5lJgqLo3VHRm+LqGjelR3Pcd7nCZC+VuonaBFzA==
   dependencies:
-    "@comunica/bus-dereference-rdf" "^2.6.8"
-    "@comunica/bus-http-invalidate" "^2.6.8"
-    "@comunica/bus-rdf-metadata" "^2.6.8"
-    "@comunica/bus-rdf-metadata-extract" "^2.6.8"
-    "@comunica/bus-rdf-update-hypermedia" "^2.6.9"
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    "@types/lru-cache" "^7.0.0"
-    lru-cache "^7.0.0"
+    "@comunica/bus-dereference-rdf" "^2.8.2"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-rdf-metadata" "^2.8.2"
+    "@comunica/bus-rdf-metadata-extract" "^2.8.2"
+    "@comunica/bus-rdf-update-hypermedia" "^2.9.0"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    lru-cache "^10.0.0"
 
-"@comunica/actor-rdf-update-quads-rdfjs-store@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.6.9.tgz#465d746f09e33425e46d496159a787fa4bb5b1d3"
-  integrity sha512-owAiRcly1k2Ww30uCqM3X8tmCiDB9rsZrVyXy3DV5nfMKyfJKy+jyaCKn3FHTxKFCaGtjJ3DUuG/WzVe5DdRmQ==
+"@comunica/actor-rdf-update-quads-rdfjs-store@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-2.9.0.tgz#dd3bab09b1fb91ea183e9c5a4c257ecd241c7b5e"
+  integrity sha512-uFB7kTJqjOXd8v6bmQHzIKW+AJLLUp11YxPnxtYz3UeDZvAG5pxkaZSTjaURHjB3AvTHE1QolnoIpJiRUBtC0Q==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bindings-factory@^2.0.1", "@comunica/bindings-factory@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/bindings-factory/-/bindings-factory-2.5.1.tgz#18fc7269dc8d11f8de28b8c8c21c80ea80464250"
-  integrity sha512-w8L9t17EaBibuyDXQAjSK04E4E3s/WWsSCNQz7QzG8dpLqscLfwiE0OBJpqpqGZ8pBkgQPt/JyC2WAqwPi5CHg==
+"@comunica/bindings-factory@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bindings-factory/-/bindings-factory-2.7.0.tgz#b35810178beed08803ba1891faf50bcd017f52c8"
+  integrity sha512-NeLbBmqiNhyUCZSfqZfwZD50dQ5+DABgPbzfuZnbHq9uSfhxAzuGCzgrK0hmuwRHWOPBtmeRnyZTJorePuxTzQ==
   dependencies:
     "@rdfjs/types" "*"
     immutable "^4.1.0"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bus-context-preprocess@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.6.8.tgz#a7fc608f752b474b60b6854ef09e5e52e934e983"
-  integrity sha512-XxDu9610qG0LlQA6jTa2RGvy8M4EzCQENp8atpB5THOvroYkKxY+PvOkq8SRWSM4v0W+tXh8LucMWDjBq3Z6lw==
+"@comunica/bus-context-preprocess@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-2.8.2.tgz#d0b9d066602d9803034a9088467730f2d31a0ffc"
+  integrity sha512-cDfiCiqBZkx+ApuZCxMgBpTEYIkbo4j1So+5pF0O3wMx+gQ0Y9rnfd2Xhw4WDZFZTGW7As52WKtBB419E+EG4w==
   dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-dereference-rdf@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.6.8.tgz#63b5ad73ac1492060349afcf3b04d75381b50855"
-  integrity sha512-pRuqz3qjwKCSLdORXgYzdqmw68CEZ3eYqBbjHTd4bLA7mSoqRPDqQKTK4dF657+6H048TYN00zGKu2fvL5lpsg==
+"@comunica/bus-dereference-rdf@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-2.8.2.tgz#3af17791b6c70447f6f45c26d9b5c35a4f83d152"
+  integrity sha512-Q/4oM6AsVi2kr9e040kZtOaeHeFao8zeV8VUgC8WceATkT6FVK/+STzOFabny1yQHSIKC54kj24pfvXJftEYhQ==
   dependencies:
-    "@comunica/bus-dereference" "^2.6.8"
-    "@comunica/bus-rdf-parse" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-dereference" "^2.8.2"
+    "@comunica/bus-rdf-parse" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-dereference@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-2.6.8.tgz#4704b2e09f1a82b418fc054243501eb45cf2b09e"
-  integrity sha512-irurPtU6QjWBowetpEUHtEp3tHq4CKUqRBCwCnRKpo09x578BwLMjOFyc4fMjm+Odlq5Up0mfPeFkJq5QpfGCQ==
+"@comunica/bus-dereference@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-2.8.2.tgz#3adacaac3fed627c721a0e49daa469746dbb781c"
+  integrity sha512-bg4A6fdkNv1CZkBJ33JvG3Xb6zloq7ElwtVMEBytzeuQV4/UuOrF8MYe9s6my+qRb3v4gDw9UYgIfePIDZMEsA==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.6.8"
-    "@comunica/actor-abstract-parse" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/actor-abstract-parse" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     readable-stream "^4.2.0"
 
-"@comunica/bus-hash-bindings@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.6.8.tgz#a8a820a4053b4cf39d695e8100777fac99beb10c"
-  integrity sha512-KRqwScO0BXAcNVuekP+nrJ+jOvKHRsAP6XVihI0gL4gzDjYyXSQYO8FU4O86+mI2t7Q00DShe67Q0gLpRT72VA==
+"@comunica/bus-hash-bindings@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-2.8.2.tgz#bb5b98ff44f03f668e614a2313fdec856dc5c4e5"
+  integrity sha512-u9ug7e08mw24NZraeOuo3qO5IFjGv88c3XPanhrtvy44xoV+uoU94KgQCwcirnjJDGHO0+tBc5ubC2+GAA/zVQ==
   dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-http-invalidate@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.6.8.tgz#6d7ee95a83c9ece7fcfa95a9085bf8878e37c1a0"
-  integrity sha512-6LvCNkw4OQ1Jw/kZ9AU1jm+fxinXVuRLqiRdaHosd8EqgMp88Du3hkH9SzHd93B5M6B5uB8WzH93u2x297DGCg==
+"@comunica/bus-http-invalidate@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-2.8.2.tgz#a761d527bc1b2d2c018ed531052084b4d17aa31c"
+  integrity sha512-hG+s+fo9o2h69DVS7VuMpnNeHzW8MJexyyzmnK1MsfGeyGIq/NmAmQGJw7kN6wYiJUgP+DlGTKlle7iCiqwgBA==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
 
 "@comunica/bus-http@^2.0.1", "@comunica/bus-http@^2.6.9":
   version "2.6.9"
@@ -1716,7 +1902,18 @@
     readable-web-to-node-stream "^3.0.2"
     web-streams-ponyfill "^1.4.2"
 
-"@comunica/bus-init@^2.0.1", "@comunica/bus-init@^2.6.8":
+"@comunica/bus-http@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-2.8.2.tgz#b51b237383db1bda2b0f0315d84ecb53cc0981d3"
+  integrity sha512-Seh7NXgTCuXbExJYgMKQDNSl8tdxaQWg5GtNiZAePE0aUwaosa2SsLifex1DJN7P1dW2OAaGzZhTB6+v9dKX4Q==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    is-stream "^2.0.1"
+    readable-stream-node-to-web "^1.0.1"
+    readable-web-to-node-stream "^3.0.2"
+    web-streams-ponyfill "^1.4.2"
+
+"@comunica/bus-init@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.6.8.tgz#487b6544a45be96e0e6b602d2bada8a7446dcf47"
   integrity sha512-GunaovksCb5GSL3ErO0oHC30XhP0E/mZ0KxixGudFZcwhHAm9YBTujSvETztXY9n2ssCRRJbdgvncFlv2Q5hjw==
@@ -1724,94 +1921,112 @@
     "@comunica/core" "^2.6.8"
     readable-stream "^4.2.0"
 
-"@comunica/bus-optimize-query-operation@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.6.8.tgz#73fab6b9eb6bb2cdb950a216787bf34e88376585"
-  integrity sha512-kgwF6ZLZqGjg/Ix6qDjZH/lpmKBwn2SRNmimvFJJg9JH7ljR63jHOXH1XG0zDYJedUuS4n9n9psZAeussdmkKQ==
+"@comunica/bus-init@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.8.2.tgz#8fb8225531de05b55008b5ac470dfd204ce00b3e"
+  integrity sha512-KvRHO0j7Z4YS1Czxm985US7/fa7aL8jUlmS1AyJnw9jcl1+gYhtDRbopyJ4DGBgfV1fxve+UFXs7gpROrrh3Ow==
   dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    sparqlalgebrajs "^4.0.5"
+    "@comunica/core" "^2.8.2"
+    readable-stream "^4.2.0"
 
-"@comunica/bus-query-operation@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-2.6.8.tgz#8a672b52cd30051f7ae9ce85f810136b6573f234"
-  integrity sha512-KeHtJB87aCcWiCC33UMT2I5fZ35dtF+hI5JSSJLjyflmAvwVR4SEEKqS/2Z3dqQYgU7OtYLDVDrzE7QZ7t8yDA==
+"@comunica/bus-optimize-query-operation@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-2.8.2.tgz#d61476c2d6691205f842f91d3d9bb6b6bc82f94f"
+  integrity sha512-jF2qNmpduRwYbCOMHJBXphCY4VOUV3tpsLDboFAzUxCD+SAzNQJ3KdlW5vBwKN2bhu2Trn/b9baRcZxPBiorDg==
   dependencies:
-    "@comunica/bindings-factory" "^2.5.1"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/data-factory" "^2.5.1"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/bus-query-operation@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-2.9.0.tgz#e28f1689c4fb1d94b64d95c7abfb770237d84708"
+  integrity sha512-2+5xq2sK8za+ijhjjEX0p3FHMVDIoS0P+RZOsQzsx54bnbI7ET9XHx9vn4AZYwGrUQRbH5+0x3UXrGrZVGRC3w==
+  dependencies:
+    "@comunica/bindings-factory" "^2.7.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/data-factory" "^2.7.0"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
     rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.0.5"
+    rdf-terms "^1.11.0"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/bus-query-parse@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-2.6.8.tgz#4e852afa21fba6fcd91867baae52aa3fe9c755b7"
-  integrity sha512-J7bQElkBK6jlbyaF4PuZsPSWyD7QYeKUfzGA43FCcr62IEjBN7UKIp2S5joTFk9G8ttiVQXTY2DLh84kX8KgsA==
+"@comunica/bus-query-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-2.8.2.tgz#482a4e5a510d42f208680340ebe26ac8d272f1b1"
+  integrity sha512-FN8ZC3rPS1p9J7zk1VllXd5cg5DSwLjFQ2wuKgsTlJLiw5nlcpc8ufwRolVsywCRVxqaHPFIKZGTXUKFh2kPeQ==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.0.5"
+    sparqlalgebrajs "^4.2.0"
 
-"@comunica/bus-query-result-serialize@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.6.8.tgz#336a755e96da66e553d55ec9367b6c277eabaf94"
-  integrity sha512-+rjtbxOknpQtCdazujOvNnSYtMSqkN/jGSTMD5NbByXeMagtqxDkH7BsL3Gn3YIcRCqD/v/Jg3skJ2x5zkW5HA==
+"@comunica/bus-query-result-serialize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-2.8.2.tgz#491fec95827f5ecb6ce309bb3791a4dfaaceaea2"
+  integrity sha512-DN1J0ZT6lHh3s24wvZzLZ4wsaJxQ/P16Oax+mTXaMf/zlXhu2ZgtXkiPt/BGtz+bVDESJjaCnq/aVSrEh28dkQ==
   dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-rdf-join-entries-sort@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.6.8.tgz#dc0c68143f0b6ad1626befa75067b13a3cdc1f33"
-  integrity sha512-IXopsZvHQbix1Pzp/hjAIw9IufKPW391G2rW4So1qwpgMM+YdfiehO9ULOJheyBtapZ3nTevRl3sxUMjBSjPLA==
+"@comunica/bus-rdf-join-entries-sort@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-2.8.2.tgz#12a4b84c3168bb9cb9bfe8f04898c59dac00d63b"
+  integrity sha512-qU06NvVdcBOl4zOHyCzA41REH/6mf708pdUNcyUZgJYfsBO3i9XQ28AHAmK+W/4AWY0sYojiIzTarWeFZ9D5yQ==
   dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-rdf-join-selectivity@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.6.8.tgz#cde8dd341cdc75e0d85506b12d234d813476c3b4"
-  integrity sha512-7pZjtTYR9VkKDFOuRZ8B1R3HkocCTBMZnBw1piMlLcw4j2rPtu+2CdogYj+L2Wdyz8xkPgJzWMXJ2vl5InXpHw==
+"@comunica/bus-rdf-join-selectivity@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-2.8.2.tgz#cf040111bde8f2da5908fdbb9e657f6bb878e5c2"
+  integrity sha512-0baorPXbBlOa/X5qL7RzjpGflWt4zTFNVBR79/KFIQZZ10kjCA+wGnooqnlUuEkXqxfKACs7dAcMsh0pM6TePw==
   dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/mediatortype-accuracy" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-accuracy" "^2.8.2"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/bus-rdf-join@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-2.6.8.tgz#2f05fdf2211abc8943f787ca647a98b272efcb55"
-  integrity sha512-2FF8i0C44uypidWUcTy8AzsO6i2CDMJM+FLW4t9P+nRm+c1EaK2Y66K4m64bRXKiBVtvZRpTXPEbDPUbyZ/JmQ==
+"@comunica/bus-rdf-join@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-2.9.0.tgz#b171f30b7660eebc097b28447b5707e7159d2bf2"
+  integrity sha512-c430gnw3Zvhe/YV/0XXcKp7xhV7mxB0vjGir1ZN6/ONqTioD7UF38JCOCgWBxmGEGU5sGIhfMK0HpPcQPtKMxg==
   dependencies:
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/bus-rdf-join-selectivity" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/bus-rdf-join-selectivity" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/metadata" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.1"
     rdf-string "^1.6.1"
 
-"@comunica/bus-rdf-metadata-extract@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.6.8.tgz#62ef6280301c16f58f4991f488bb6feb931e2a7b"
-  integrity sha512-/MNSQDKYTmXSZKPMMSgW0Hk1ca/nsP16sPtYJ3OmT/rIIi8w92vFj+F7LsPKaWUvK2Z2lKnI6fjvz1B3invVuA==
+"@comunica/bus-rdf-metadata-accumulate@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-2.8.2.tgz#8e04d2e7144b525c0cad57a07aaf832b8163f6e7"
+  integrity sha512-Tl/DfkqLsn800rqcfj+/ntY2CiDs0YYoCPfMV6WL4xpaVVWTjWTUXSjDEpEzXdMTlrje0A66N5nSt88qDAlc2Q==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/bus-rdf-metadata-extract@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-2.8.2.tgz#e26b1d7dda09e47d125230d57c91c2c21f57ae3a"
+  integrity sha512-9PofdgPuun5lcRjpO6DlpLlnsVlcy1qBAx2mqe3mzIYVEfOHXWrdE+Dn54AEIic5PkZGJT4k6xxelv8G3HDwXg==
+  dependencies:
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-metadata@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.6.8.tgz#8cd68396a68004d7ee4f89215a75c426cdf1934b"
-  integrity sha512-GVvLWf3PXMWkmxpwvfHSYXPAuYNAyNHAUOiZuWzzh0dtfJ4tkc/rInAPXR3sFyTKmuzskG4GabqFmLZworEzdw==
+"@comunica/bus-rdf-metadata@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-2.8.2.tgz#983b8c61f1a1aa6942b2b245dd6d21b16a6f0229"
+  integrity sha512-g1JznI5motRlGwlZbX9IwflJfnt81QQqfdlDLmHZQxMdjvVeDPNcmdvimguBTW6MoU3VLJhiDchXp9rh9vweZA==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse-html@^2.0.1", "@comunica/bus-rdf-parse-html@^2.6.8":
@@ -1820,6 +2035,14 @@
   integrity sha512-tYbPp1IS2pcxbLU4ihj2XXqP//LxccH/CvTDvvbaJ867Nr/BC2E6hhp/gIFAFOX+Qinfe7noSHqhdOrX090Z8w==
   dependencies:
     "@comunica/core" "^2.6.8"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-rdf-parse-html@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-2.8.2.tgz#a2e07b39ea64b0759b61a7f33a6787d8c8e5fb43"
+  integrity sha512-r20sl/NPC2YJCPFfWUCSYVZzYhoKK1ZJ0UJ8HubKte8EURG3TqUb9hQKSMcq9GbqSASR/lPUwSLL4VuKKD3aTw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse@^2.0.1", "@comunica/bus-rdf-parse@^2.6.8":
@@ -1832,79 +2055,94 @@
     "@comunica/core" "^2.6.8"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-hypermedia-links-queue@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.6.8.tgz#a13a0fc3d97d7cd790c585bb078505390649fa7d"
-  integrity sha512-rBR8TMInqsSM6YTAM5qSIKU/7qq1u9sCUAOKoee3TSIvSOJZI8jGPg4diKBYw/LgWPTEzJiSjVYKRmFXzSktDw==
+"@comunica/bus-rdf-parse@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-2.8.2.tgz#cec32710484186e103fbba1e958fd59fc513538a"
+  integrity sha512-XimvJuWJGuolpUs4w+im4fw8Lc8jPj6gKM/2fE/cenWO/m6RafnvcOqjMs80toueuoFRaF/TIxOY09t6G+p0VA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-
-"@comunica/bus-rdf-resolve-hypermedia-links@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.6.8.tgz#11e0af16f24c8cb92da8fa2f5a21a19fb79ce3fe"
-  integrity sha512-lhgq7Y8c50ECQt0Mhwy4shktKCth0/WcoFEnoTzEfIDqLydkOqa6DYpsFDGFNpCW743Z/6a7o2AMlFqjB0AIMw==
-  dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/actor-abstract-parse" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-hypermedia@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.6.8.tgz#db262a9e00aab332dbb2beef375725789521a790"
-  integrity sha512-AL+ZlGZXM0CCB0YWfmXpqhbAN3qrCIeHO2esX5pDLtSOIhLqtgldpQiqU+ry8JuUwnebFYGL/h9KE+HzVviMPA==
+"@comunica/bus-rdf-resolve-hypermedia-links-queue@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-2.8.2.tgz#fee89493c8c6086560d39634b8e4a29edf542734"
+  integrity sha512-oUHYfWHNczCq6CHN2wKWV5+SeMlp9lEsJ+2GycrHPKFsLxwSAFelxi3FZgNowwFFR62Wp/UkPi4RjcA6UN46og==
   dependencies:
-    "@comunica/bus-rdf-resolve-quad-pattern" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/bus-rdf-resolve-hypermedia-links@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-2.8.2.tgz#1691b68b264aa2433ba9320561a0c416b29cd218"
+  integrity sha512-RFHEcPs/UGziKfxLKJhufVVusVH4rMvwEI7y1QQ2rlDFErL8fNjzz4vUioBnigS5KqNVJHphszZkgSpSWDrdWw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-quad-pattern@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.6.8.tgz#920631fc54cc3a703ea42b5ee2eb887aceb22ee4"
-  integrity sha512-b58VH6T5dwW15xUsX4es3H1k7THDf4gxqM2btwzGE/09rPBCM2gYfTpCv0PmPZ4S49p2BH5sy/zkg3IGi+8BjA==
+"@comunica/bus-rdf-resolve-hypermedia@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-2.8.2.tgz#4736f2ed69f81b8cfb3c2aa082b372ca56aa1d8a"
+  integrity sha512-Jyepb3vCQ63T217e5AJcUZp+5EmJI8y2ZHAvzl050x8YKZRUTST2gfMoY3rB8WCPs7TFn9R2T5bR9ez/QRwOZg==
   dependencies:
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
-    "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
-    sparqlalgebrajs "^4.0.5"
-
-"@comunica/bus-rdf-serialize@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.6.8.tgz#0bde30e28ba38100bbcdcf676278831497292e1f"
-  integrity sha512-6KUN/puzpd2Zm/3NY8Mkv0xAZ1Io4e/5sMenIJNXVPphJSpFJRsMZL8p4An1OZoFCkd4PGgFy/l1JuZekUWgPw==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/bus-rdf-resolve-quad-pattern" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-update-hypermedia@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.6.9.tgz#c61a1bb196ec3fd94c8f32cafe319ef626d4db8f"
-  integrity sha512-HB3zxPzhFFAbBdFncv/uLRuR6EG1yGKA3pZgjjRKXS29IjNukzhiUQUJ0A8UTmci6pTNFnkgzqVefuEiFzldLw==
+"@comunica/bus-rdf-resolve-quad-pattern@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-2.8.2.tgz#ecebf39061020b2ad3b972ce1cd57686de7b4f39"
+  integrity sha512-TZPa/h5dERgL8oJY8wZn9fR4lxaE9cgiwPRJKgZjGN4mM8MaBY76qZXa55EqbcZnj4YihpLUoHcizj1cqC1mKA==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^2.6.9"
-    "@comunica/core" "^2.6.8"
-
-"@comunica/bus-rdf-update-quads@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.6.9.tgz#3c57b78f18d7a2e64849110b0a341930645cb749"
-  integrity sha512-8lc1bPL8IH6Elg1W3DlbdmAvANUrFeFnXl5lhzqGc/wV66w7sHFPXdwpZKF+pQRqFeZGafW4qEk4wKKfFlCUmw==
-  dependencies:
-    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.6.8"
-    "@comunica/bus-http" "^2.6.9"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
     "@rdfjs/types" "*"
-    asynciterator "^3.8.0"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
+
+"@comunica/bus-rdf-serialize@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-2.8.2.tgz#77660f0c66a935f926fd0633389a726255eb940d"
+  integrity sha512-HAmDo3p1uw7WM/oUERa+1/UKcoATIHk6DCJgzXBWocwniCLb7b2sHQJR/SteFyH0U01JIgIn7cYyQsFkmfewHg==
+  dependencies:
+    "@comunica/actor-abstract-mediatyped" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-rdf-update-hypermedia@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-2.9.0.tgz#5a40dd4f6f4b4df5abb04e8a1ec8b91f0c197d09"
+  integrity sha512-wxbzF71oIrwD8qjD9XyRoOA11nb0OMZCjCAhxzJ5Dv8lkIR89TyxsCV//6/wAsz76nuuYKV3b1MCetvlO6E94A==
+  dependencies:
+    "@comunica/bus-rdf-update-quads" "^2.9.0"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/bus-rdf-update-quads@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-2.9.0.tgz#87468234705caefdab78e8f9f1b7dc89e930d962"
+  integrity sha512-n8GmXIrw00OsyWleuBpGVyfzGlFYdgzK9Y7EcePWnreu6yIf001n9P9GdRb9NN7DrF5ylFV7BthTv+PmIxXgNA==
+  dependencies:
+    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.9.0"
+    "@comunica/bus-http" "^2.8.2"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.1"
     stream-to-string "^1.2.0"
 
-"@comunica/config-query-sparql@^2.0.1", "@comunica/config-query-sparql@^2.6.0":
+"@comunica/config-query-sparql@^2.0.1":
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.6.0.tgz#a52af16bf592e91db2bc148c1b20bfe98a4c76d2"
   integrity sha512-Ih02KeThu1RWdiV7JfpD8u0lc3hu547EG5pDhe9igGPjU+ijNbahfJJzKrR7LcJrMTGtydEN+z2allIlBKSftA==
+
+"@comunica/config-query-sparql@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz#1030ee76d5532bc6a09a6c8af26a06c7311a5861"
+  integrity sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==
 
 "@comunica/context-entries@^2.6.8":
   version "2.6.8"
@@ -1917,6 +2155,17 @@
     jsonld-context-parser "^2.2.2"
     sparqlalgebrajs "^4.0.5"
 
+"@comunica/context-entries@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-2.8.2.tgz#d1c8e46756c05e84232679f53d35a7f4006e9998"
+  integrity sha512-Ycub6tUiK3qYjKaT74DiThv4IKq3M4SAvDB0AdFvcevwcU6OK8Z6H7M7uA5LehJiEKoBwiO4Ff8iuv3xqAF+tw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    "@rdfjs/types" "*"
+    jsonld-context-parser "^2.2.2"
+    sparqlalgebrajs "^4.2.0"
+
 "@comunica/core@^2.0.1", "@comunica/core@^2.6.8":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.6.8.tgz#719a9d2f5176bc0715e9503ba06bbe905c5a59e6"
@@ -1925,36 +2174,63 @@
     "@comunica/types" "^2.6.8"
     immutable "^4.1.0"
 
-"@comunica/data-factory@^2.5.1":
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/@comunica/data-factory/-/data-factory-2.5.1.tgz#c4b44d3124219a305aff85437c121bf456bb93a1"
-  integrity sha512-QngIzTIgEkgO1yIuoXADz5vQV6jXqmKMVrKR0E80Ko73pPnc0fah486CD2Q1CMI613rwStH/U1Sot2t1DOhi9w==
+"@comunica/core@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.8.2.tgz#ed1006d076ccd8f87180cc66e0b242a92c527815"
+  integrity sha512-8UrhEilUDxRTltFCI4uxz3nch02lGK1KFHBUCUxp/9EmnnQUYvwbMCMS6sLxYHTqJ18/SMFFEwgBMsTX/N+wuA==
+  dependencies:
+    "@comunica/types" "^2.8.2"
+    immutable "^4.1.0"
+
+"@comunica/data-factory@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@comunica/data-factory/-/data-factory-2.7.0.tgz#616f9abe7804f3627aadc0baec2632a9c68ec62b"
+  integrity sha512-dSTzrR1w9SzAWx70ZXKXHUC8f0leUolLZ9TOhGjFhhsBMJ9Pbo0g6vHV8txX5FViShngrg9QNKhsHeQnMk5z6Q==
   dependencies:
     "@rdfjs/types" "*"
 
-"@comunica/logger-pretty@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-2.6.8.tgz#f88fc798563e73c7df4a33ad53f4edd02cec907f"
-  integrity sha512-kN9R2GvGARVXoON4y0oaYK+Ac+0B3ZQXKaHSDbEURZEIPPGOyeYzTbGhtIITcVVnb4kUEgGHMhe0LQdLJFP6rA==
+"@comunica/expression-evaluator@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/expression-evaluator/-/expression-evaluator-2.9.0.tgz#8fa5092aad809e49d8ab40a88165247a9fba7e62"
+  integrity sha512-BCIQSzuZ2BHC+lGnz4Zr+XDPdnEHX8hlK2CaT/dTYX3eo1vQ0MISxQZuPkvvMJ6GuySFAd5rjX6aluf8XoG5xw==
   dependencies:
-    "@comunica/types" "^2.6.8"
+    "@rdfjs/types" "*"
+    "@types/spark-md5" "^3.0.2"
+    "@types/uuid" "^9.0.0"
+    bignumber.js "^9.0.1"
+    hash.js "^1.1.7"
+    lru-cache "^10.0.0"
+    rdf-data-factory "^1.1.2"
+    rdf-string "^1.6.3"
+    relative-to-absolute-iri "^1.0.6"
+    spark-md5 "^3.0.1"
+    sparqlalgebrajs "^4.2.0"
+    uuid "^9.0.0"
+
+"@comunica/logger-pretty@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-2.8.2.tgz#aef33c0e652280dbb9b3011f1bdbfe971ef02807"
+  integrity sha512-aeS2/+zAYMiTokAaGQ8kuP+tapGi2hjXwNUeRl0OzhPLYU7x1hZamqRScWBWLrIFNwRR3p4EVcH8mJC3y2P9PA==
+  dependencies:
+    "@comunica/types" "^2.8.2"
     object-inspect "^1.12.2"
+    process "^0.11.10"
 
-"@comunica/logger-void@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-2.6.8.tgz#974e8fe6bc03f90d802292d55f2a55447d857eff"
-  integrity sha512-Z3USbXpKMs+4SJ3c7boYtGC2owJ7dJzaC5QML9mfblkDsFYx2INfNQnMIz+wb8zYK5+PyArMIvdGFA28ACoXdQ==
+"@comunica/logger-void@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-2.8.2.tgz#cda5aa7b25f0c343e831c0b9a4c264bff0ce534d"
+  integrity sha512-76VpfNCCO034PBSn4SUBp0CpbPhRM1g8AVJ5TV29RygOkOYBv+p3Pdzxgt/ITuyRswbuet0b553DpHkGStUTNw==
   dependencies:
-    "@comunica/types" "^2.6.8"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/mediator-all@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-2.6.8.tgz#fc82d02374a1c853013386a0a6eea3b9763f2809"
-  integrity sha512-/JxrW35idDPCZSH8t0J0ETjZ9zyGrXJgbpd+0RBj2fUGqfR5sy0+JzHRnl/9wChbL4tluwEX9CnNqbCqRLmBlw==
+"@comunica/mediator-all@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-2.8.2.tgz#46ec6361d1576f9314deb5f9da0576cfe23594fc"
+  integrity sha512-O1ZaeC70D106F38uGHZWejY1HajMhyY7PpipDrt+Kvdt8JYcfVkTx6dN1DFkyJ8PVmJnRrZkMqj1q1IunSJDag==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediator-combine-pipeline@^2.0.1", "@comunica/mediator-combine-pipeline@^2.6.8":
+"@comunica/mediator-combine-pipeline@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.6.8.tgz#b8fa87fb54ee01075f4113174a90547571b41cf4"
   integrity sha512-6vH2+gPrfY0esKeiURfMQncRaQNElp7WCMKXYWiJYhIJvpLdigNG90jDBbrNbPJNNE6PSmINBVEKxlO59mVA3A==
@@ -1962,58 +2238,87 @@
     "@comunica/core" "^2.6.8"
     "@comunica/types" "^2.6.8"
 
-"@comunica/mediator-combine-union@^2.0.1", "@comunica/mediator-combine-union@^2.6.8":
+"@comunica/mediator-combine-pipeline@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-2.8.2.tgz#09333ee9e69202ec34a37613229f999281beb138"
+  integrity sha512-XjN3EWdKC2XDY6gr1po5GttsRuM1FewzW3KRlLoYkRzH0+S3Th5Ef6zTlgDef4tWqVgNXIzC5Ccz0HraKKEbdg==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/mediator-combine-union@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-2.6.8.tgz#527672f4e67fec6360275ea2b06f57a890b24540"
   integrity sha512-XNR84eBB5CkHC+S4mcl2Htf8vgT3OGLW7BhcYgMn6eQOsFzTQcKluLJpVeQ5vC/gIcmiK5dpgN5Pqn5iGM+KZQ==
   dependencies:
     "@comunica/core" "^2.6.8"
 
-"@comunica/mediator-join-coefficients-fixed@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.6.8.tgz#d49f016459db57e54829aa4be344a3b184b8945b"
-  integrity sha512-nuOyddFK85FnyVeoaXAHPkSnr0NV9T+cUtDYoIZgZKVrdihrX/GdEyXp03RkwNv0eqPgtf8fXBRPgqHtEwQ/rg==
+"@comunica/mediator-combine-union@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-2.8.2.tgz#71be8ca6050443a49cdbaf273434895d2c780168"
+  integrity sha512-TjSHJdtbdiV96m+GaPUT+44Q4SOG8dcESO3YuJhRklAf6oOYfXL9d+7ITixSo7tiZQSv1LlgxG1apzBDTM1BvA==
   dependencies:
-    "@comunica/bus-rdf-join" "^2.6.8"
-    "@comunica/context-entries" "^2.6.8"
-    "@comunica/core" "^2.6.8"
-    "@comunica/mediatortype-join-coefficients" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediator-number@^2.0.1", "@comunica/mediator-number@^2.6.8":
+"@comunica/mediator-join-coefficients-fixed@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-2.9.0.tgz#b7fd40fc869b88de796e8ccf2caef8558530e88f"
+  integrity sha512-8TYvaqnV8YG1CkeGaYZA/f4OwgdxHJ4DGvv/9moJaCitHVwCbiwZWbg6c4KJ1oluntcXXNpGGmHG4c2w6JL3Og==
+  dependencies:
+    "@comunica/bus-rdf-join" "^2.9.0"
+    "@comunica/context-entries" "^2.8.2"
+    "@comunica/core" "^2.8.2"
+    "@comunica/mediatortype-join-coefficients" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+
+"@comunica/mediator-number@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-2.6.8.tgz#112f615317d31727a11b6f329294189f686fff96"
   integrity sha512-0K1uagchvhSLR/yeGMCTid3M9s7YNkHh1UTWqCLAl294DoJeaVgvn6AuCo3cq0kUIdK/gnobpiqLqcuErTW6Ig==
   dependencies:
     "@comunica/core" "^2.6.8"
 
-"@comunica/mediator-race@^2.0.1", "@comunica/mediator-race@^2.6.8":
+"@comunica/mediator-number@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-2.8.2.tgz#447f7951db02e24755b3dc477bf0326bbc5f12ad"
+  integrity sha512-7VP1bMUusiG7AecQxrPfSunK408+oW4kdNNjavEJ7+pLi/95bT/e/rq/0wbK9Wu0vVrn7JNbliekLdhdI/BIuA==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+
+"@comunica/mediator-race@^2.0.1":
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-2.6.8.tgz#b63a28419b26c95afe5f2567136a3bbb976d87c7"
   integrity sha512-8Ck91/pNxkhRwd0DItB8Rhuw/26UTFYAmz5lV7jQt3rbG2izCMezOEl5b9uaYGN82Mb1Q85Zj/qEz+AQQAr20w==
   dependencies:
     "@comunica/core" "^2.6.8"
 
-"@comunica/mediatortype-accuracy@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.6.8.tgz#f07b9719d3332fcef381f9e4b1aafcc11bd1e559"
-  integrity sha512-lGjAVDa3V0FtW6zgy/T8V1XiTZeAe06G/wz/djoopLXenxML0jcxYNgYU7s3w0uUlVy9+aTWzV6JHfil5EucAw==
+"@comunica/mediator-race@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-2.8.2.tgz#d77507aca27170599943c2bb1c39aeaa14134831"
+  integrity sha512-oD9bw8YLV8TTedFBigPuqWKNxu64uLwsfve0OYV2J0tZHPTiYp8XJoeWN1mxc0q4TimxqXfKn4gXD5MP06MUsQ==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediatortype-httprequests@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.6.8.tgz#bf37c846da711ce01c89c9474285643756c99e17"
-  integrity sha512-2ZmXsj/n9zXkm8BdOEkwInOVMymfFbS2EKbR7EvmTwT4gYvDuqBeYFzJzGBpv7U/5wP8PoQSigqUaE4t+18uEA==
+"@comunica/mediatortype-accuracy@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-2.8.2.tgz#a569ff4bcb16016cdfbaa3d3c3147cffa1b17a70"
+  integrity sha512-VWHhtoAhIQvwVGxWW2G75dzcnd8QIaeSSm4IAuVjteUniuXdUoktvCI1GH4kyVw/HUfVmFwslDrGs8rUh+uPKQ==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/mediatortype-join-coefficients@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.6.8.tgz#397135918bc6cdcac2de74c5950d1f10422838fa"
-  integrity sha512-kNr6/1cHV7M/u/WURQZP79AFUHjVu9kcd9vVnq2/f1AV53ekxfLfQFsmcRzxJAO+Gndp/dgbE69WiIIrPJFQPQ==
+"@comunica/mediatortype-httprequests@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-httprequests/-/mediatortype-httprequests-2.8.2.tgz#a0973fa85029844dc9f2a6b3665bca202185beda"
+  integrity sha512-ftYYMcPNHHORpeSFFCmeBXfmZuNUeFCJS1DGkLrjMfHufDvyFpMaU1WrOXDwa8y0g9UvF5V12O7To9WcE5FPhg==
   dependencies:
-    "@comunica/core" "^2.6.8"
+    "@comunica/core" "^2.8.2"
+
+"@comunica/mediatortype-join-coefficients@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-2.8.2.tgz#29b9735e1f0dd8b26b162589dedb928cf07dc6b2"
+  integrity sha512-nvu+WPs1048U19YUBBZsR8UDs+fmTVGrc2cRHiSW1w6EkcgMnIMV9OR6pvmSZAoy4XNcZb8hbV4nS+ETYb7yqw==
+  dependencies:
+    "@comunica/core" "^2.8.2"
     "@rdfjs/types" "*"
 
 "@comunica/mediatortype-time@^2.6.8":
@@ -2023,155 +2328,177 @@
   dependencies:
     "@comunica/core" "^2.6.8"
 
-"@comunica/query-sparql@^2.6.9":
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/@comunica/query-sparql/-/query-sparql-2.6.9.tgz#899b465fe2c0b50edd841ee746383a59e5c06e34"
-  integrity sha512-ycDXCUVJKISNbvUk/6vxR/plbmo1CRUFnNwy97BByv3pg7nyE65MxxQAXhZY/511tGs+x9vIKp5HAf9xfzl+GQ==
+"@comunica/mediatortype-time@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-time/-/mediatortype-time-2.8.2.tgz#c0232b9b66fcd2b7214366974bd5543c651395ad"
+  integrity sha512-ZNApJwoE5iwO9o1GGYhjYzJeNmkvWggiNGkvYyRvua0HrMa3fXzZJSzU5I9Dkoh3lzfNsgPemoO+vg/SiH8WyA==
   dependencies:
-    "@comunica/actor-context-preprocess-source-to-destination" "^2.6.8"
-    "@comunica/actor-dereference-fallback" "^2.6.8"
-    "@comunica/actor-dereference-http" "^2.6.9"
-    "@comunica/actor-dereference-rdf-parse" "^2.6.8"
-    "@comunica/actor-hash-bindings-sha1" "^2.6.8"
-    "@comunica/actor-http-fetch" "^2.6.9"
-    "@comunica/actor-http-proxy" "^2.6.9"
-    "@comunica/actor-http-wayback" "^2.6.9"
-    "@comunica/actor-init-query" "^2.6.9"
-    "@comunica/actor-optimize-query-operation-bgp-to-join" "^2.6.8"
-    "@comunica/actor-optimize-query-operation-join-bgp" "^2.6.8"
-    "@comunica/actor-optimize-query-operation-join-connected" "^2.6.8"
-    "@comunica/actor-query-operation-ask" "^2.6.8"
-    "@comunica/actor-query-operation-bgp-join" "^2.6.8"
-    "@comunica/actor-query-operation-construct" "^2.6.8"
-    "@comunica/actor-query-operation-describe-subject" "^2.6.8"
-    "@comunica/actor-query-operation-distinct-hash" "^2.6.8"
-    "@comunica/actor-query-operation-extend" "^2.6.8"
-    "@comunica/actor-query-operation-filter-sparqlee" "^2.6.8"
-    "@comunica/actor-query-operation-from-quad" "^2.6.8"
-    "@comunica/actor-query-operation-group" "^2.6.8"
-    "@comunica/actor-query-operation-join" "^2.6.8"
-    "@comunica/actor-query-operation-leftjoin" "^2.6.9"
-    "@comunica/actor-query-operation-minus" "^2.6.8"
-    "@comunica/actor-query-operation-nop" "^2.6.8"
-    "@comunica/actor-query-operation-orderby-sparqlee" "^2.6.8"
-    "@comunica/actor-query-operation-path-alt" "^2.6.8"
-    "@comunica/actor-query-operation-path-inv" "^2.6.8"
-    "@comunica/actor-query-operation-path-link" "^2.6.8"
-    "@comunica/actor-query-operation-path-nps" "^2.6.8"
-    "@comunica/actor-query-operation-path-one-or-more" "^2.6.8"
-    "@comunica/actor-query-operation-path-seq" "^2.6.8"
-    "@comunica/actor-query-operation-path-zero-or-more" "^2.6.8"
-    "@comunica/actor-query-operation-path-zero-or-one" "^2.6.8"
-    "@comunica/actor-query-operation-project" "^2.6.8"
-    "@comunica/actor-query-operation-quadpattern" "^2.6.8"
-    "@comunica/actor-query-operation-reduced-hash" "^2.6.8"
-    "@comunica/actor-query-operation-service" "^2.6.8"
-    "@comunica/actor-query-operation-slice" "^2.6.8"
-    "@comunica/actor-query-operation-sparql-endpoint" "^2.6.9"
-    "@comunica/actor-query-operation-union" "^2.6.8"
-    "@comunica/actor-query-operation-update-add-rewrite" "^2.6.8"
-    "@comunica/actor-query-operation-update-clear" "^2.6.9"
-    "@comunica/actor-query-operation-update-compositeupdate" "^2.6.8"
-    "@comunica/actor-query-operation-update-copy-rewrite" "^2.6.8"
-    "@comunica/actor-query-operation-update-create" "^2.6.9"
-    "@comunica/actor-query-operation-update-deleteinsert" "^2.6.9"
-    "@comunica/actor-query-operation-update-drop" "^2.6.9"
-    "@comunica/actor-query-operation-update-load" "^2.6.9"
-    "@comunica/actor-query-operation-update-move-rewrite" "^2.6.8"
-    "@comunica/actor-query-operation-values" "^2.6.8"
-    "@comunica/actor-query-parse-graphql" "^2.6.8"
-    "@comunica/actor-query-parse-sparql" "^2.6.8"
-    "@comunica/actor-query-result-serialize-json" "^2.6.8"
-    "@comunica/actor-query-result-serialize-rdf" "^2.6.8"
-    "@comunica/actor-query-result-serialize-simple" "^2.6.8"
-    "@comunica/actor-query-result-serialize-sparql-csv" "^2.6.8"
-    "@comunica/actor-query-result-serialize-sparql-json" "^2.6.9"
-    "@comunica/actor-query-result-serialize-sparql-tsv" "^2.6.8"
-    "@comunica/actor-query-result-serialize-sparql-xml" "^2.6.8"
-    "@comunica/actor-query-result-serialize-stats" "^2.6.9"
-    "@comunica/actor-query-result-serialize-table" "^2.6.8"
-    "@comunica/actor-query-result-serialize-tree" "^2.6.8"
-    "@comunica/actor-rdf-join-entries-sort-cardinality" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-hash" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-multi-bind" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-multi-empty" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-multi-smallest" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-nestedloop" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-none" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-single" "^2.6.8"
-    "@comunica/actor-rdf-join-inner-symmetrichash" "^2.6.8"
-    "@comunica/actor-rdf-join-minus-hash" "^2.6.8"
-    "@comunica/actor-rdf-join-minus-hash-undef" "^2.6.8"
-    "@comunica/actor-rdf-join-optional-bind" "^2.6.8"
-    "@comunica/actor-rdf-join-optional-nestedloop" "^2.6.8"
-    "@comunica/actor-rdf-join-selectivity-variable-counting" "^2.6.8"
-    "@comunica/actor-rdf-metadata-all" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-allow-http-methods" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-hydra-count" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-hydra-pagesize" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-patch-sparql-update" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-put-accepted" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-request-time" "^2.6.8"
-    "@comunica/actor-rdf-metadata-extract-sparql-service" "^2.6.8"
-    "@comunica/actor-rdf-metadata-primary-topic" "^2.6.8"
-    "@comunica/actor-rdf-parse-html" "^2.6.8"
-    "@comunica/actor-rdf-parse-html-microdata" "^2.6.8"
-    "@comunica/actor-rdf-parse-html-rdfa" "^2.6.8"
-    "@comunica/actor-rdf-parse-html-script" "^2.6.8"
-    "@comunica/actor-rdf-parse-jsonld" "^2.6.9"
-    "@comunica/actor-rdf-parse-n3" "^2.6.8"
-    "@comunica/actor-rdf-parse-rdfxml" "^2.6.8"
-    "@comunica/actor-rdf-parse-shaclc" "^2.6.8"
-    "@comunica/actor-rdf-parse-xml-rdfa" "^2.6.8"
-    "@comunica/actor-rdf-resolve-hypermedia-links-next" "^2.6.8"
-    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo" "^2.6.8"
-    "@comunica/actor-rdf-resolve-hypermedia-none" "^2.6.8"
-    "@comunica/actor-rdf-resolve-hypermedia-qpf" "^2.6.8"
-    "@comunica/actor-rdf-resolve-hypermedia-sparql" "^2.6.9"
-    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.6.8"
-    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia" "^2.6.9"
-    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.6.8"
-    "@comunica/actor-rdf-resolve-quad-pattern-string-source" "^2.6.8"
-    "@comunica/actor-rdf-serialize-jsonld" "^2.6.8"
-    "@comunica/actor-rdf-serialize-n3" "^2.6.8"
-    "@comunica/actor-rdf-serialize-shaclc" "^2.6.8"
-    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update" "^2.6.9"
-    "@comunica/actor-rdf-update-hypermedia-put-ldp" "^2.6.9"
-    "@comunica/actor-rdf-update-hypermedia-sparql" "^2.6.9"
-    "@comunica/actor-rdf-update-quads-hypermedia" "^2.6.9"
-    "@comunica/actor-rdf-update-quads-rdfjs-store" "^2.6.9"
-    "@comunica/bus-http-invalidate" "^2.6.8"
-    "@comunica/bus-query-operation" "^2.6.8"
-    "@comunica/config-query-sparql" "^2.6.0"
-    "@comunica/core" "^2.6.8"
-    "@comunica/logger-void" "^2.6.8"
-    "@comunica/mediator-all" "^2.6.8"
-    "@comunica/mediator-combine-pipeline" "^2.6.8"
-    "@comunica/mediator-combine-union" "^2.6.8"
-    "@comunica/mediator-join-coefficients-fixed" "^2.6.8"
-    "@comunica/mediator-number" "^2.6.8"
-    "@comunica/mediator-race" "^2.6.8"
-    "@comunica/runner" "^2.6.8"
-    "@comunica/runner-cli" "^2.6.8"
+    "@comunica/core" "^2.8.2"
 
-"@comunica/runner-cli@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/runner-cli/-/runner-cli-2.6.8.tgz#93aecd3cb5a350bad59ac28fef1344c3123f41ff"
-  integrity sha512-QY/ARcgaRBfAegwABCXCM0cQiTvlc9d3E6+t3+OcgnOfRgw+IogTJmb34g6aelYYs6ywXxAs8gG7kmEbxx65hQ==
+"@comunica/metadata@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/metadata/-/metadata-2.8.2.tgz#1c8eafa5f3c4eaa1bd4cac4db680f062b813f712"
+  integrity sha512-/yznxjOo+/6yJkdb45wfWig5waIhAv+qKd79D2EAt26EAy43thBXgGORxDTOx8vULPG3ij5SIDcNRZ7vJwJO8Q==
   dependencies:
-    "@comunica/core" "^2.6.8"
-    "@comunica/runner" "^2.6.8"
-    "@comunica/types" "^2.6.8"
+    "@comunica/types" "^2.8.2"
 
-"@comunica/runner@^2.6.8":
-  version "2.6.8"
-  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-2.6.8.tgz#52e34282d3cbb46af7bdaa4b7b1bad2e967b4b95"
-  integrity sha512-N7BAQP6WFKvHfFM//tTDjJ9YHWbT9wMURNMB0njRsq//E0ewxLYwVN/XaPXwxbq+rbPzSrGHL25sYgQ+GJf7kA==
+"@comunica/query-sparql@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@comunica/query-sparql/-/query-sparql-2.9.0.tgz#1c9a3538be110a9b8569fc3e4f6b2ebd08d69091"
+  integrity sha512-LW5OGVwusyWWHTbyaeWDRM/BmF6+dBrFfW82u9mVVHOOWELmCoEX5g/1bhRI9lLjEk14e1n+n0NfUeNBdCHNKQ==
   dependencies:
-    "@comunica/bus-init" "^2.6.8"
-    "@comunica/core" "^2.6.8"
+    "@comunica/actor-context-preprocess-source-to-destination" "^2.8.2"
+    "@comunica/actor-dereference-fallback" "^2.8.2"
+    "@comunica/actor-dereference-http" "^2.8.2"
+    "@comunica/actor-dereference-rdf-parse" "^2.8.2"
+    "@comunica/actor-hash-bindings-sha1" "^2.8.2"
+    "@comunica/actor-http-fetch" "^2.8.2"
+    "@comunica/actor-http-proxy" "^2.8.2"
+    "@comunica/actor-http-wayback" "^2.8.2"
+    "@comunica/actor-init-query" "^2.9.0"
+    "@comunica/actor-optimize-query-operation-bgp-to-join" "^2.8.2"
+    "@comunica/actor-optimize-query-operation-join-bgp" "^2.8.2"
+    "@comunica/actor-optimize-query-operation-join-connected" "^2.8.2"
+    "@comunica/actor-query-operation-ask" "^2.9.0"
+    "@comunica/actor-query-operation-bgp-join" "^2.9.0"
+    "@comunica/actor-query-operation-construct" "^2.9.0"
+    "@comunica/actor-query-operation-describe-subject" "^2.9.0"
+    "@comunica/actor-query-operation-distinct-hash" "^2.9.0"
+    "@comunica/actor-query-operation-extend" "^2.9.0"
+    "@comunica/actor-query-operation-filter-sparqlee" "^2.9.0"
+    "@comunica/actor-query-operation-from-quad" "^2.9.0"
+    "@comunica/actor-query-operation-group" "^2.9.0"
+    "@comunica/actor-query-operation-join" "^2.9.0"
+    "@comunica/actor-query-operation-leftjoin" "^2.9.0"
+    "@comunica/actor-query-operation-minus" "^2.9.0"
+    "@comunica/actor-query-operation-nop" "^2.9.0"
+    "@comunica/actor-query-operation-orderby-sparqlee" "^2.9.0"
+    "@comunica/actor-query-operation-path-alt" "^2.9.0"
+    "@comunica/actor-query-operation-path-inv" "^2.9.0"
+    "@comunica/actor-query-operation-path-link" "^2.9.0"
+    "@comunica/actor-query-operation-path-nps" "^2.9.0"
+    "@comunica/actor-query-operation-path-one-or-more" "^2.9.0"
+    "@comunica/actor-query-operation-path-seq" "^2.9.0"
+    "@comunica/actor-query-operation-path-zero-or-more" "^2.9.0"
+    "@comunica/actor-query-operation-path-zero-or-one" "^2.9.0"
+    "@comunica/actor-query-operation-project" "^2.9.0"
+    "@comunica/actor-query-operation-quadpattern" "^2.9.0"
+    "@comunica/actor-query-operation-reduced-hash" "^2.9.0"
+    "@comunica/actor-query-operation-service" "^2.9.0"
+    "@comunica/actor-query-operation-slice" "^2.9.0"
+    "@comunica/actor-query-operation-sparql-endpoint" "^2.9.0"
+    "@comunica/actor-query-operation-union" "^2.9.0"
+    "@comunica/actor-query-operation-update-add-rewrite" "^2.9.0"
+    "@comunica/actor-query-operation-update-clear" "^2.9.0"
+    "@comunica/actor-query-operation-update-compositeupdate" "^2.9.0"
+    "@comunica/actor-query-operation-update-copy-rewrite" "^2.9.0"
+    "@comunica/actor-query-operation-update-create" "^2.9.0"
+    "@comunica/actor-query-operation-update-deleteinsert" "^2.9.0"
+    "@comunica/actor-query-operation-update-drop" "^2.9.0"
+    "@comunica/actor-query-operation-update-load" "^2.9.0"
+    "@comunica/actor-query-operation-update-move-rewrite" "^2.9.0"
+    "@comunica/actor-query-operation-values" "^2.9.0"
+    "@comunica/actor-query-parse-graphql" "^2.8.2"
+    "@comunica/actor-query-parse-sparql" "^2.8.2"
+    "@comunica/actor-query-result-serialize-json" "^2.8.2"
+    "@comunica/actor-query-result-serialize-rdf" "^2.8.2"
+    "@comunica/actor-query-result-serialize-simple" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-csv" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-json" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-tsv" "^2.8.2"
+    "@comunica/actor-query-result-serialize-sparql-xml" "^2.8.2"
+    "@comunica/actor-query-result-serialize-stats" "^2.8.2"
+    "@comunica/actor-query-result-serialize-table" "^2.8.2"
+    "@comunica/actor-query-result-serialize-tree" "^2.8.2"
+    "@comunica/actor-rdf-join-entries-sort-cardinality" "^2.8.2"
+    "@comunica/actor-rdf-join-inner-hash" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-multi-empty" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-multi-smallest" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-nestedloop" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-none" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-single" "^2.9.0"
+    "@comunica/actor-rdf-join-inner-symmetrichash" "^2.9.0"
+    "@comunica/actor-rdf-join-minus-hash" "^2.9.0"
+    "@comunica/actor-rdf-join-minus-hash-undef" "^2.9.0"
+    "@comunica/actor-rdf-join-optional-bind" "^2.9.0"
+    "@comunica/actor-rdf-join-optional-nestedloop" "^2.9.0"
+    "@comunica/actor-rdf-join-selectivity-variable-counting" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-cancontainundefs" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-cardinality" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-pagesize" "^2.8.2"
+    "@comunica/actor-rdf-metadata-accumulate-requesttime" "^2.8.2"
+    "@comunica/actor-rdf-metadata-all" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-allow-http-methods" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-count" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-pagesize" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-patch-sparql-update" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-put-accepted" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-request-time" "^2.8.2"
+    "@comunica/actor-rdf-metadata-extract-sparql-service" "^2.8.2"
+    "@comunica/actor-rdf-metadata-primary-topic" "^2.8.2"
+    "@comunica/actor-rdf-parse-html" "^2.8.2"
+    "@comunica/actor-rdf-parse-html-microdata" "^2.8.2"
+    "@comunica/actor-rdf-parse-html-rdfa" "^2.8.2"
+    "@comunica/actor-rdf-parse-html-script" "^2.8.2"
+    "@comunica/actor-rdf-parse-jsonld" "^2.8.2"
+    "@comunica/actor-rdf-parse-n3" "^2.8.2"
+    "@comunica/actor-rdf-parse-rdfxml" "^2.8.2"
+    "@comunica/actor-rdf-parse-shaclc" "^2.8.2"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-links-next" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-none" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-qpf" "^2.8.2"
+    "@comunica/actor-rdf-resolve-hypermedia-sparql" "^2.8.3"
+    "@comunica/actor-rdf-resolve-quad-pattern-federated" "^2.9.0"
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia" "^2.9.0"
+    "@comunica/actor-rdf-resolve-quad-pattern-rdfjs-source" "^2.8.2"
+    "@comunica/actor-rdf-resolve-quad-pattern-string-source" "^2.8.2"
+    "@comunica/actor-rdf-serialize-jsonld" "^2.8.2"
+    "@comunica/actor-rdf-serialize-n3" "^2.8.2"
+    "@comunica/actor-rdf-serialize-shaclc" "^2.8.2"
+    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update" "^2.9.0"
+    "@comunica/actor-rdf-update-hypermedia-put-ldp" "^2.9.0"
+    "@comunica/actor-rdf-update-hypermedia-sparql" "^2.9.0"
+    "@comunica/actor-rdf-update-quads-hypermedia" "^2.9.0"
+    "@comunica/actor-rdf-update-quads-rdfjs-store" "^2.9.0"
+    "@comunica/bus-http-invalidate" "^2.8.2"
+    "@comunica/bus-query-operation" "^2.9.0"
+    "@comunica/config-query-sparql" "^2.7.0"
+    "@comunica/core" "^2.8.2"
+    "@comunica/logger-void" "^2.8.2"
+    "@comunica/mediator-all" "^2.8.2"
+    "@comunica/mediator-combine-pipeline" "^2.8.2"
+    "@comunica/mediator-combine-union" "^2.8.2"
+    "@comunica/mediator-join-coefficients-fixed" "^2.9.0"
+    "@comunica/mediator-number" "^2.8.2"
+    "@comunica/mediator-race" "^2.8.2"
+    "@comunica/runner" "^2.8.2"
+    "@comunica/runner-cli" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    process "^0.11.10"
+
+"@comunica/runner-cli@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/runner-cli/-/runner-cli-2.8.2.tgz#64aab0402ab5dc4f84cb41da1ffa21bbbb7b6757"
+  integrity sha512-FB7ciWt8YTKy1pFDNgdDCgJirPQ6tGk6xIhnpwo/vQ7cyRwIAddXOfOHCGdEqyOLFO/57PD7PB2G3GjhEJTu1Q==
+  dependencies:
+    "@comunica/core" "^2.8.2"
+    "@comunica/runner" "^2.8.2"
+    "@comunica/types" "^2.8.2"
+    process "^0.11.10"
+
+"@comunica/runner@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-2.8.2.tgz#453b0b0d18414165a72695bb923b237867ef3564"
+  integrity sha512-a6DzNfPT6k5zdesuytEZ7BjqShlwQoZIovqUguty49+NRIP6KbYkCousQlgYWY2uKNazmjJaSYIO6QWCJBJ7Fg==
+  dependencies:
+    "@comunica/bus-init" "^2.8.2"
+    "@comunica/core" "^2.8.2"
     componentsjs "^5.3.2"
+    process "^0.11.10"
 
 "@comunica/types@^2.6.8":
   version "2.6.8"
@@ -2182,6 +2509,16 @@
     "@types/yargs" "^17.0.13"
     asynciterator "^3.8.0"
     sparqlalgebrajs "^4.0.5"
+
+"@comunica/types@^2.8.2":
+  version "2.8.2"
+  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-2.8.2.tgz#b910c1ed767118958184e47432c9cc47e9c4c884"
+  integrity sha512-gF/wlBtr0Q1VVozYna7DLYlIU528vqinpc0MJ67uvFALJJHP9uqhjOsmVokdoEirf1WIut5GkEp33IGyBvOv5Q==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@types/yargs" "^17.0.13"
+    asynciterator "^3.8.1"
+    sparqlalgebrajs "^4.2.0"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.3"
@@ -2574,18 +2911,6 @@
   resolved "https://registry.npmjs.org/@types/json-stable-stringify/-/json-stable-stringify-1.0.34.tgz"
   integrity sha512-s2cfwagOQAS8o06TcwKfr9Wx11dNGbH2E9vJz1cqV+a/LOyhWNLUNd6JSRYNzvB4d29UuJX2M0Dj9vE1T8fRXw==
 
-"@types/lru-cache@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-5.1.1.tgz#c48c2e27b65d2a153b19bfc1a317e30872e01eef"
-  integrity sha512-ssE3Vlrys7sdIzs5LOxCzTVMsU7i9oa/IaW92wF32JFb3CVczqOkru2xspuKczHEbG3nvmPY7IFqVmGGHdNbYw==
-
-"@types/lru-cache@^7.0.0":
-  version "7.10.10"
-  resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-7.10.10.tgz#3fa937c35ff4b3f6753d5737915c9bf8e693a713"
-  integrity sha512-nEpVRPWW9EBmx2SCfNn3ClYxPL7IktPX12HhIoSc/H5mMjdeW3+YsXIpseLQ2xF35+OcpwKQbEUw5VtqE4PDNA==
-  dependencies:
-    lru-cache "*"
-
 "@types/minimist@^1.2.0":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
@@ -2666,10 +2991,10 @@
   resolved "https://registry.yarnpkg.com/@types/uritemplate/-/uritemplate-0.3.4.tgz#c7a7f2b7e16b212baa69623183cde641659a4b97"
   integrity sha512-1D8mJEeQEXynoPQKJkneIK+tXaM2Qnk6c80RBQPV/O2ToypI4mlqXy5jojnYKjTX2Q+EMNMOWt0wNdLbb2MUpA==
 
-"@types/uuid@^8.0.0":
-  version "8.3.4"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
-  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+"@types/uuid@^9.0.0":
+  version "9.0.5"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.5.tgz#25a71eb73eba95ac0e559ff3dd018fc08294acf6"
+  integrity sha512-xfHdwa1FMJ082prjSJpoEI57GZITiQz10r3vEJCHa2khEFQjKy91aWKz6+zybzssCvXUwE1LQWgWVwZ4nYUvHQ==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -2794,6 +3119,11 @@ asynciterator@^3.6.0, asynciterator@^3.8.0:
   version "3.8.0"
   resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.8.0.tgz#d9246a3d39ce2a9e4b020834d7f352adf35b49d8"
   integrity sha512-bD34LqKHJnkB77MHjL3hOAUOcy9dbB+3lHvL+EiJpD3k2Nyq3i1dCk5adMisB2rwlrHVu/+XRhOdPZL9hzpsfw==
+
+asynciterator@^3.8.1:
+  version "3.8.1"
+  resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.8.1.tgz#80be735b252332494e186ee733544e5b21dd2123"
+  integrity sha512-SmdG0FUY3pYGOZZGdYq8Qb/DCRDXBFZUk08V1/4lbBXdAQvcC3Kxzz9FUDPBTik7VAVltt4cZirAPtJv3gOpEw==
 
 asyncjoin@^1.1.1:
   version "1.1.2"
@@ -2999,10 +3329,15 @@ caniuse-lite@^1.0.30001366:
   resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001366.tgz"
   integrity sha512-yy7XLWCubDobokgzudpkKux8e0UOOnLHE6mlNJBzT3lZJz6s5atSEzjoL+fsCPkI0G8MP5uVdDx1ur/fXEWkZA==
 
-canonicalize@^1.0.1, canonicalize@^1.0.8:
+canonicalize@^1.0.1:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.8.tgz#24d1f1a00ed202faafd9bf8e63352cd4450c6df1"
   integrity sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==
+
+canonicalize@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-2.0.0.tgz#32be2cef4446d67fd5348027a384cae28f17226a"
+  integrity sha512-ulDEYPv7asdKvqahuAY35c1selLdzDwHqugK92hfkzvlDCwXRRelDkR+Er33md/PtnpqHemgkuDPanZ4fiYZ8w==
 
 caseless@~0.12.0:
   version "0.12.0"
@@ -3204,6 +3539,13 @@ cross-fetch@^3.0.6, cross-fetch@^3.1.5:
   dependencies:
     node-fetch "2.6.7"
 
+cross-fetch@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz"
@@ -3329,6 +3671,15 @@ domutils@^3.0.1:
     domelementtype "^2.3.0"
     domhandler "^5.0.1"
 
+domutils@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
+  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+  dependencies:
+    dom-serializer "^2.0.0"
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+
 ecc-jsbn@~0.1.1:
   version "0.1.2"
   resolved "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz"
@@ -3361,6 +3712,11 @@ entities@^4.2.0, entities@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
   integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
+
+entities@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -3472,10 +3828,10 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
-fetch-sparql-endpoint@^3.1.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-3.2.1.tgz#6202dc7ac119bad4b2f9b2b1d208e2dcb08ff896"
-  integrity sha512-RPq/OYBHrNvCKAtjlxDu3uBHsKBlKOkwqzbQldHAUYp0ZZ/UxWWOzNKgq8zKsY4/1sW6Qlju7MHX7KdK5WP0lg==
+fetch-sparql-endpoint@^4.0.0, fetch-sparql-endpoint@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-4.1.0.tgz#6c5c66983035d51773092248c9d869a511d9d7c2"
+  integrity sha512-RQwr4+RpEiWZqubPCv05t7t1Y8ZDAmiJ4cCo0Ee9vmet4bjnDIiZIpAtJn9NMLBeVxpZfxGiPFcX6V0v2yVcUA==
   dependencies:
     "@rdfjs/types" "*"
     "@types/readable-stream" "^2.3.11"
@@ -3488,8 +3844,8 @@ fetch-sparql-endpoint@^3.1.1:
     rdf-string "^1.6.0"
     readable-web-to-node-stream "^3.0.2"
     sparqljs "^3.1.2"
-    sparqljson-parse "^2.1.0"
-    sparqlxml-parse "^2.0.0"
+    sparqljson-parse "^2.2.0"
+    sparqlxml-parse "^2.1.1"
     stream-to-string "^1.1.0"
 
 fill-range@^7.0.1:
@@ -3712,6 +4068,16 @@ htmlparser2@^8.0.0, htmlparser2@^8.0.1:
     domhandler "^5.0.3"
     domutils "^3.0.1"
     entities "^4.4.0"
+
+htmlparser2@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-9.0.0.tgz#e431142b7eeb1d91672742dea48af8ac7140cddb"
+  integrity sha512-uxbSI98wmFT/G4P2zXx4OVx04qWUmyFPrD2/CNepa2Zo3GPNaCaaxElDgwUrwYWkK1nr9fft0Ya8dws8coDLLQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.1.0"
+    entities "^4.5.0"
 
 http-link-header@^1.0.2:
   version "1.1.0"
@@ -4361,7 +4727,7 @@ jsonld-streaming-parser@^3.0.1, jsonld-streaming-parser@^3.2.0:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
-jsonld-streaming-serializer@^2.0.1:
+jsonld-streaming-serializer@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-2.1.0.tgz#db80d6e13d74ae5837a313123ea4d409b04df2e0"
   integrity sha512-COHdLoeMTnrqHMoFhN3PoAwqnrKrpPC7/ACb0WbELYvt+HSOIFN3v4IJP7fOtLNQ4GeaeYkvbeWJ7Jo4EjxMDw==
@@ -4480,10 +4846,10 @@ loud-rejection@^1.0.0:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
 
-lru-cache@*, lru-cache@^7.0.0, lru-cache@^7.14.1:
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
-  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
+lru-cache@^10.0.0:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.0.1.tgz#0a3be479df549cca0e5d693ac402ff19537a6b7a"
+  integrity sha512-IJ4uwUTi2qCccrioU6g9g/5rvvVl13bsdczUUcqbciD9iLr095yj8DQKdObriEvuNSx325N1rV1O0sJFszx75g==
 
 lru-cache@^4.0.1:
   version "4.1.5"
@@ -4674,14 +5040,6 @@ ms@^2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-n3@^1.11.1:
-  version "1.16.3"
-  resolved "https://registry.yarnpkg.com/n3/-/n3-1.16.3.tgz#d339dca14c79648b1595a3252c5410b800b896f8"
-  integrity sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==
-  dependencies:
-    queue-microtask "^1.1.2"
-    readable-stream "^4.0.0"
-
 n3@^1.16.3, n3@^1.6.3:
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.16.4.tgz#6747e9e63e1b6656c1ce02a29707471307b23c04"
@@ -4712,6 +5070,13 @@ node-fetch@2.6.7:
   version "2.6.7"
   resolved "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz"
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
+
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
   dependencies:
     whatwg-url "^5.0.0"
 
@@ -5003,6 +5368,13 @@ rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1:
   dependencies:
     "@rdfjs/types" "*"
 
+rdf-data-factory@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz#d47550d2649d0d64f8cae3fcc9efae7a8a895d9a"
+  integrity sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==
+  dependencies:
+    "@rdfjs/types" "*"
+
 rdf-isomorphic@^1.3.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/rdf-isomorphic/-/rdf-isomorphic-1.3.1.tgz#cd6d433cd85bf79d903d5f0fdeea42a40eb27265"
@@ -5078,18 +5450,29 @@ rdf-quad@^1.5.0:
     rdf-literal "^1.2.0"
     rdf-string "^1.5.0"
 
-rdf-store-stream@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-1.3.1.tgz#41045dd0a403135d767459d64ec3ec449f77e16e"
-  integrity sha512-+cpnGKJMwFbCa/L0fogSMrNA95P+T2tSoWWXj94IdGN2UdYu+oQpaP7vav5wGenWQ1J9/nQu6Sy0m+stNfAZFw==
+rdf-store-stream@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-2.0.0.tgz#941932d4f20859a93e495586d2bd501aa0408f2f"
+  integrity sha512-FKRsA5XUdhFVMx+jg4JCBM76B4ZcXVKyilr8GJrlfkHB2IZSIgLxY2XHIsewkDfm/yAtXHvPT0PaeQg4Mbqa6g==
   dependencies:
     "@rdfjs/types" "*"
-    n3 "^1.11.1"
+    rdf-stores "^1.0.0"
 
-rdf-streaming-store@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/rdf-streaming-store/-/rdf-streaming-store-1.0.2.tgz#e373c1aa633c047c339ae023233d801c2d1c9b30"
-  integrity sha512-+clYrm8tSfAhTBRZ6NIE5i/JmYZE0B/2Vu8SOCel+lfarjXZwlejoVeA+a/AHcl+lrF2yGh+iw16SsHoE23uTA==
+rdf-stores@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-stores/-/rdf-stores-1.0.0.tgz#1689bd669853bda857620d0db32f3b59940db208"
+  integrity sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==
+  dependencies:
+    "@rdfjs/types" "*"
+    asynciterator "^3.8.0"
+    rdf-data-factory "^1.1.1"
+    rdf-string "^1.6.2"
+    rdf-terms "^1.9.1"
+
+rdf-streaming-store@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rdf-streaming-store/-/rdf-streaming-store-1.1.0.tgz#a00be02eeb1616e577a095dad9afe96d9106fcfa"
+  integrity sha512-C/5NTKGpKrNJ5VUo42DtGFsXYDlP3rx/u4C6gEBuSn+6eVFahjFdUDgNGcPtVyhCQkctRCj3GT1lX9UeyoXWtw==
   dependencies:
     "@rdfjs/types" "*"
     "@types/n3" "^1.10.4"
@@ -5107,13 +5490,22 @@ rdf-string-ttl@^1.3.2:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
 
-rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.2:
+rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.2, rdf-string@^1.6.3:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
   integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
   dependencies:
     "@rdfjs/types" "*"
     rdf-data-factory "^1.1.0"
+
+rdf-terms@^1.10.0, rdf-terms@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
+  integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
+  dependencies:
+    "@rdfjs/types" "*"
+    rdf-data-factory "^1.1.0"
+    rdf-string "^1.6.0"
 
 rdf-terms@^1.7.0, rdf-terms@^1.9.1:
   version "1.9.1"
@@ -5147,6 +5539,20 @@ rdfxml-streaming-parser@^2.0.0, rdfxml-streaming-parser@^2.2.1:
     readable-stream "^4.0.0"
     relative-to-absolute-iri "^1.0.0"
     saxes "^6.0.0"
+    validate-iri "^1.0.0"
+
+rdfxml-streaming-parser@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz#ca362b5557068b37334e44790912e7ca5b089a1a"
+  integrity sha512-HoH8urnga+YQ5sDY9ufRb0wg6FvwR284sSXpZ+fJE5X5Oej6dfzkFer81uBNZzyNmzJR1TpMYMznyXEjPMLhCA==
+  dependencies:
+    "@rdfjs/types" "*"
+    "@rubensworks/saxes" "^6.0.1"
+    "@types/readable-stream" "^2.3.13"
+    buffer "^6.0.3"
+    rdf-data-factory "^1.1.0"
+    readable-stream "^4.0.0"
+    relative-to-absolute-iri "^1.0.0"
     validate-iri "^1.0.0"
 
 react-is@^18.0.0:
@@ -5387,6 +5793,14 @@ shaclc-parse@^1.3.0:
     "@rdfjs/types" "^1.1.0"
     n3 "^1.16.3"
 
+shaclc-parse@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.4.0.tgz#1a82643daf0f7309ca8722d9bee4ee40f2726925"
+  integrity sha512-zyxjIYQH2ghg/wtMvOp+4Nr6aK8j9bqFiVT3w47K8WHPYN+S3Zgnh2ybT+dGgMwo9KjiOoywxhjC7d8Z6GCmfA==
+  dependencies:
+    "@rdfjs/types" "^1.1.0"
+    n3 "^1.16.3"
+
 shaclc-write@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.4.2.tgz#1262e30d40da3353858e67f0972330bcef498418"
@@ -5460,7 +5874,7 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.3, sparqlalgebrajs@^4.0.5:
+sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.5:
   version "4.0.5"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.0.5.tgz#054cd4dbbe9c2e2ecc345948fd5a7cfad1d475a4"
   integrity sha512-upGjNvjl5QfEFTBTzp65Lt7D5zsXrVpgJw+4fYgwZdtscegMBM6s+4PNhWaGnuQ80gQyEtD+r4WE2l/yWA+r9A==
@@ -5474,25 +5888,20 @@ sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.0.3, sparqlalgebrajs@^4.0.5:
     rdf-string "^1.6.0"
     sparqljs "^3.6.1"
 
-sparqlee@^2.2.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/sparqlee/-/sparqlee-2.2.1.tgz#56a7b237fdebb42053e6be608fc5265cebbd4440"
-  integrity sha512-nRBiqNpqUzI4F3/EMyTy+mKc7ijxnw+BpbTuRuc5e25TmYdyzPQzAwGeLFIfWPNd8biJ2fqK4ZxIjHdWdRbhfQ==
+sparqlalgebrajs@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.3.0.tgz#73fa0abb4deb25c71e8965a748dbc0ba05d4f040"
+  integrity sha512-l6Urelb/X5CozXEhfHis37Kbr0iZLS6uuE3pB/NYqvE0A7aYqkkFy+9n8vxEnkfNTg5CLFftYN7ukPyicYrVyw==
   dependencies:
-    "@comunica/bindings-factory" "^2.0.1"
-    "@rdfjs/types" "^1.1.0"
-    "@types/lru-cache" "^5.1.1"
-    "@types/spark-md5" "^3.0.2"
-    "@types/uuid" "^8.0.0"
-    bignumber.js "^9.0.1"
-    hash.js "^1.1.7"
-    lru-cache "^6.0.0"
+    "@rdfjs/types" "*"
+    "@types/sparqljs" "^3.1.3"
+    fast-deep-equal "^3.1.3"
+    minimist "^1.2.6"
     rdf-data-factory "^1.1.0"
+    rdf-isomorphic "^1.3.0"
     rdf-string "^1.6.0"
-    relative-to-absolute-iri "^1.0.6"
-    spark-md5 "^3.0.1"
-    sparqlalgebrajs "^4.0.3"
-    uuid "^8.0.0"
+    rdf-terms "^1.10.0"
+    sparqljs "^3.7.1"
 
 sparqljs@^3.1.2, sparqljs@^3.6.1:
   version "3.6.2"
@@ -5501,7 +5910,14 @@ sparqljs@^3.1.2, sparqljs@^3.6.1:
   dependencies:
     rdf-data-factory "^1.1.1"
 
-sparqljson-parse@^2.0.0, sparqljson-parse@^2.1.0, sparqljson-parse@^2.2.0:
+sparqljs@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.1.tgz#5d121895d491d50214f2e38f2885a3a935b6c093"
+  integrity sha512-I1jYMtcwDkgCEqQ4eQuQIhB8hFAlRAJ6YDXDcV54XztaJaYRFqJlidHt77S3j8Mfh6kY6GK04dXPEIopxbEeuQ==
+  dependencies:
+    rdf-data-factory "^1.1.2"
+
+sparqljson-parse@^2.0.0, sparqljson-parse@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-2.2.0.tgz#58c788e896f7d2c0d3079452d8812943049d4a7e"
   integrity sha512-2TfvNvUsaJyWfCrq3ExdDdbF9LBLzIUCricg+D1YCYbbmyTzscgCtRk4KcIyJF178DtfCt4BkKzbKl8IXMHp8w==
@@ -5519,18 +5935,6 @@ sparqljson-to-tree@^3.0.1:
   dependencies:
     rdf-literal "^1.2.0"
     sparqljson-parse "^2.0.0"
-
-sparqlxml-parse@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-2.1.0.tgz#8486ac5c25efb3386eb4dea6a7af855d2b66c3d4"
-  integrity sha512-JAQ526Bz07FQ6dbPMwVQBaOP55bc91Jnp/KCTPoTQa7JQcmxjKwaSMhlKNAQ+ChEzRt76tWhQkmutwPzd4YRmQ==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/readable-stream" "^2.3.13"
-    buffer "^6.0.3"
-    rdf-data-factory "^1.1.0"
-    readable-stream "^4.0.0"
-    saxes "^6.0.0"
 
 sparqlxml-parse@^2.1.1:
   version "2.1.1"
@@ -5947,10 +6351,10 @@ uuid@^3.3.2:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.0.0:
-  version "8.3.2"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
-  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+uuid@^9.0.0:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.0.1"


### PR DESCRIPTION
This is to cope with the restructuring over in https://github.com/w3c/rdf-tests in the work happening on RDF 1.2.

This is a blocker for continuing work on https://github.com/rubensworks/rdf-test-suite.js/issues/94.