### PR TITLE
Support serviceData for federated query tests

### DIFF
--- a/lib/context-manifest.json
+++ b/lib/context-manifest.json
@@ -29,6 +29,8 @@
   "graph": "q:graph",
   "graphData": "q:graphData",
   "query": "q:query",
+  "serviceData": "q:serviceData",
+  "endpoint": "q:endpoint",
 
   "ut": "http://www.w3.org/2009/sparql/tests/test-update#",
   "updateQuery": "ut:request",

--- a/lib/testcase/sparql/TestCaseQueryEvaluation.ts
+++ b/lib/testcase/sparql/TestCaseQueryEvaluation.ts
@@ -331,6 +331,34 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
     return queryData;
   }
 
+  /**
+   * Obtain all service data links for the given query test action.
+   * @param action A query test action.
+   */
+  public static getServiceDataLinks(action: Resource): IServiceDataLink[] {
+    const serviceDataLinks: IServiceDataLink[] = [];
+    for (const serviceData of action.properties.serviceData) {
+      serviceDataLinks.push({
+        endpoint: serviceData.property.endpoint.value,
+        dataUri: serviceData.property.data.value,
+      });
+    }
+    return serviceDataLinks;
+  }
+
+  /**
+   * Resolve service data links to a mapping of endpoint URIs to their quads.
+   * @param serviceDataLinks Links to service data.
+   * @param options Fetch options.
+   */
+  public static async resolveServiceDataLinks(serviceDataLinks: IServiceDataLink[], options?: IFetchOptions): Promise<Record<string, RDF.Quad[]>> {
+    const serviceData: Record<string, RDF.Quad[]> = {};
+    for (const link of serviceDataLinks) {
+      serviceData[link.endpoint] = await arrayifyStream((await Util.fetchRdf(link.dataUri, { ...options, normalizeUrl: true }))[1]);
+    }
+    return serviceData;
+  }
+
   public async resourceToTestCase(resource: Resource, testCaseData: ITestCaseData, options?: IFetchOptions): Promise<TestCaseQueryEvaluation> {
     if (!resource.property.action) {
       throw new Error(`Missing mf:action in ${resource}`);
@@ -346,6 +374,9 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
     // Determine links to data
     const queryDataLinks: IQueryDataLink[] = TestCaseQueryEvaluationHandler.getQueryDataLinks(action);
 
+    // Determine links to service data (for federated query tests)
+    const serviceDataLinks: IServiceDataLink[] = TestCaseQueryEvaluationHandler.getServiceDataLinks(action);
+
     // Check for lax cardinality property
     let laxCardinality = false;
     if (resource.property.resultCardinality && resource.property.resultCardinality.value ===
@@ -356,14 +387,19 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
     // Collect all query data
     const queryData: RDF.Quad[] = await TestCaseQueryEvaluationHandler.resolveQueryDataLinks(queryDataLinks, options);
 
+    // Resolve service data for federated queries
+    const serviceData: Record<string, RDF.Quad[]> = await TestCaseQueryEvaluationHandler.resolveServiceDataLinks(serviceDataLinks, options);
+
     const queryResponse = await Util.fetchCached(resource.property.result.value, options);
     return new TestCaseQueryEvaluation(
       testCaseData,
       {
         baseIRI: Util.normalizeBaseUrl(action.property.query.value),
         queryDataLinks,
+        serviceDataLinks,
         laxCardinality,
         queryData,
+        serviceData,
         queryResult: await TestCaseQueryEvaluationHandler.parseQueryResult(
           Util.identifyContentType(queryResponse.url, queryResponse.headers),
           queryResponse.url,
@@ -380,15 +416,22 @@ export interface ITestCaseQueryEvaluationProps {
   baseIRI: string;
   queryString: string;
   queryData: RDF.Quad[];
+  serviceData: Record<string, RDF.Quad[]>;
   queryResult: IQueryResult;
   laxCardinality: boolean;
   resultSource: IFetchResponse;
   queryDataLinks: IQueryDataLink[];
+  serviceDataLinks: IServiceDataLink[];
 }
 
 export interface IQueryDataLink {
   dataUri: string;
   dataGraph?: RDF.NamedNode;
+}
+
+export interface IServiceDataLink {
+  endpoint: string;
+  dataUri: string;
 }
 
 export class TestCaseQueryEvaluation implements ITestCaseSparql {
@@ -403,9 +446,11 @@ export class TestCaseQueryEvaluation implements ITestCaseSparql {
   public readonly baseIRI: string;
   public readonly queryString: string;
   public readonly queryData: RDF.Quad[];
+  public readonly serviceData: Record<string, RDF.Quad[]>;
   public readonly queryResult: IQueryResult;
   public readonly laxCardinality: boolean;
   public readonly queryDataLinks: IQueryDataLink[];
+  public readonly serviceDataLinks: IServiceDataLink[];
   public readonly resultSource: IFetchResponse;
 
   constructor(testCaseData: ITestCaseData, props: ITestCaseQueryEvaluationProps) {
@@ -417,14 +462,27 @@ export class TestCaseQueryEvaluation implements ITestCaseSparql {
     return queryDataLinks.map(queryDataLink => queryDataLink.dataUri + (queryDataLink.dataGraph ? ` (named graph: ${queryDataLink.dataGraph.value})` : '')).join(',\n    ');
   }
 
+  public static serviceDataLinksToString(serviceDataLinks: IServiceDataLink[]): string {
+    if (serviceDataLinks.length === 0) {
+      return 'None';
+    }
+    return serviceDataLinks.map(link => `${link.endpoint} (data: ${link.dataUri})`).join(',\n    ');
+  }
+
   public async test(engine: IQueryEngine, injectArguments: any): Promise<void> {
-    const result: IQueryResult = await engine.query(this.queryData, this.queryString, { baseIRI: this.baseIRI, ...injectArguments });
+    const options: Record<string, any> = { baseIRI: this.baseIRI, ...injectArguments };
+    if (Object.keys(this.serviceData).length > 0) {
+      options.serviceData = this.serviceData;
+    }
+    const result: IQueryResult = await engine.query(this.queryData, this.queryString, options);
     if (!this.queryResult.equals(result, this.laxCardinality)) {
       throw new ErrorTest(`Invalid query evaluation
 
   Query:\n\n${this.queryString}
 
   Data links: ${TestCaseQueryEvaluation.queryDataLinksToString(this.queryDataLinks)}
+
+  Service links: ${TestCaseQueryEvaluation.serviceDataLinksToString(this.serviceDataLinks)}
 
   Result Source: ${this.resultSource.url}
 

--- a/test/testcase/sparql/TestCaseQueryEvaluation-test.ts
+++ b/test/testcase/sparql/TestCaseQueryEvaluation-test.ts
@@ -45,6 +45,10 @@ const DF = new DataFactory();
     "RDF1.1 XML Syntax 1", "RDF1.1 XML Syntax 2".`);
       headers = new Headers({ 'Content-Type': 'text/turtle' });
       break;
+    case 'ENDPOINT.ttl':
+      body = streamifyString(`<http://example.org/s> <http://example.org/p> <http://example.org/o>.`);
+      headers = new Headers({ 'Content-Type': 'text/turtle' });
+      break;
     default:
       return Promise.reject(new Error(`Fetch error for ${url}`));
   }
@@ -72,6 +76,8 @@ describe('TestCaseQueryEvaluationHandler', () => {
   let pGraphData;
   let pGraph;
   let pLabel;
+  let pServiceData;
+  let pEndpoint;
 
   beforeEach((done) => {
     new ContextParser().parse(require('../../../lib/context-manifest.json'))
@@ -101,6 +107,12 @@ describe('TestCaseQueryEvaluationHandler', () => {
         );
         pLabel = new Resource(
           { term: DF.namedNode('http://www.w3.org/2000/01/rdf-schema#label'), context },
+        );
+        pServiceData = new Resource(
+          { term: DF.namedNode('http://www.w3.org/2001/sw/DataAccess/tests/test-query#serviceData'), context },
+        );
+        pEndpoint = new Resource(
+          { term: DF.namedNode('http://www.w3.org/2001/sw/DataAccess/tests/test-query#endpoint'), context },
         );
 
         done();
@@ -618,6 +630,44 @@ describe('TestCaseQueryEvaluationHandler', () => {
     });
   });
 
+  describe('#getServiceDataLinks', () => {
+    it('should return service data links from an action', () => {
+      const action = new Resource({ term: DF.namedNode('action'), context });
+      const serviceData = new Resource({ term: DF.namedNode('sd1'), context });
+
+      serviceData.addProperty(pEndpoint, new Resource({ term: DF.namedNode('http://example.org/sparql'), context }));
+      serviceData.addProperty(pData, new Resource({ term: DF.namedNode('ENDPOINT.ttl'), context }));
+      action.addProperty(pServiceData, serviceData);
+
+      expect(TestCaseQueryEvaluationHandler.getServiceDataLinks(action)).toEqual([
+        { endpoint: 'http://example.org/sparql', dataUri: 'ENDPOINT.ttl' },
+      ]);
+    });
+  });
+
+  describe('#resolveServiceDataLinks', () => {
+    it('should fetch and map service data quads by endpoint', async() => {
+      const links = [{ endpoint: 'http://example.org/sparql', dataUri: 'ENDPOINT.ttl' }];
+      const resolved = await TestCaseQueryEvaluationHandler.resolveServiceDataLinks(links);
+
+      expect(resolved['http://example.org/sparql']).toBeRdfIsomorphic([
+        quad('http://example.org/s', 'http://example.org/p', 'http://example.org/o'),
+      ]);
+    });
+  });
+
+  describe('#serviceDataLinksToString', () => {
+    it('should handle the empty array', () => {
+      expect(TestCaseQueryEvaluation.serviceDataLinksToString([])).toBe('None');
+    });
+
+    it('should handle a non-empty array', () => {
+      expect(TestCaseQueryEvaluation.serviceDataLinksToString([
+        { endpoint: 'http://example.org/sparql', dataUri: 'ENDPOINT.ttl' },
+      ])).toBe(`http://example.org/sparql (data: ENDPOINT.ttl)`);
+    });
+  });
+
   describe('#resourceToTestCase', () => {
     it('should produce a TestCaseQueryEvaluation', async() => {
       const resource = new Resource({ term: DF.namedNode('http://ex.org/test'), context });
@@ -834,6 +884,33 @@ describe('TestCaseQueryEvaluationHandler', () => {
       resource.addProperty(pResult, new Resource({ term: DF.literal('RESULT_OTHER.ttl'), context }));
       const testCase = await handler.resourceToTestCase(resource, <any> {});
       return expect(testCase.test(engine, {})).rejects.toBeTruthy();
+    });
+
+    it('should produce a TestCaseQueryEvaluation with service data for federated queries', async() => {
+      const resource = new Resource({ term: DF.namedNode('http://ex.org/test'), context });
+      const action = new Resource({ term: DF.namedNode('blabla'), context });
+      action.addProperty(pQuery, new Resource({ term: DF.literal('ACTION.ok'), context }));
+
+      const serviceData = new Resource({ term: DF.namedNode('sd1'), context });
+      serviceData.addProperty(pEndpoint, new Resource({ term: DF.namedNode('http://example.org/sparql'), context }));
+      serviceData.addProperty(pData, new Resource({ term: DF.namedNode('ENDPOINT.ttl'), context }));
+      action.addProperty(pServiceData, serviceData);
+
+      resource.addProperty(pAction, action);
+      resource.addProperty(pResult, new Resource({ term: DF.literal('RESULT.ttl'), context }));
+
+      const testCase = await handler.resourceToTestCase(resource, <any> {});
+
+      expect(testCase).toBeInstanceOf(TestCaseQueryEvaluation);
+      expect(testCase.type).toBe('sparql');
+      expect(testCase.serviceDataLinks).toEqual([
+        { endpoint: 'http://example.org/sparql', dataUri: 'ENDPOINT.ttl' },
+      ]);
+      expect(testCase.serviceData['http://example.org/sparql']).toBeRdfIsomorphic([
+        quad('http://example.org/s', 'http://example.org/p', 'http://example.org/o'),
+      ]);
+
+      await expect(testCase.test(engine, {})).resolves.toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Federated query tests use `qt:serviceData` in the manifest to specify mock SPARQL endpoint data. Previously, `rdf-test-suite` did not support this property. This PR implements the necessary extraction and resolution logic to support these federated query tests.