### PR TITLE
Support SPARQL 1.1 Service Description Tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ $ rdf-test-suite myengine.js http://w3c.github.io/rdf-tests/sparql/sparql11/mani
   -i '{ "myProperty": "myValue" }'
 ```
 
+The SPARQL 1.1 Service Description tests require the endpoint under test:
+
+```bash
+$ rdf-test-suite myengine.js http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl \
+  -s http://www.w3.org/TR/sparql11-service-description/ \
+  -i '{ "serviceDescriptionEndpoint": "http://localhost:3000/sparql" }'
+```
+
 ### Test timeouts
 
 By default, all tests are allowed to run 3000 ms.
@@ -301,7 +309,7 @@ $ rdf-test-suite myengine.js https://w3c.github.io/rdf-tests/sparql/sparql11/man
 | [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 Results JSON](http://www.w3.org/TR/sparql11-results-json/) | [`IQueryEngine`](https://github.com/rubensworks/rdf-test-suite.js/blob/master/lib/testcase/sparql/IQueryEngine.ts) | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
 | [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 Federated Query](http://www.w3.org/TR/sparql11-federated-query/) | ✖ | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
 | [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 Entailment](http://www.w3.org/TR/sparql11-entailment/) | ✖ | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
-| [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 Service Description](http://www.w3.org/TR/sparql11-service-description/) | ✖ | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
+| [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 Service Description](http://www.w3.org/TR/sparql11-service-description/) | ✔ | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
 | [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 Protocol](http://www.w3.org/TR/sparql11-protocol/) | ✖ | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
 | [SPARQL 1.1 tests](https://w3c.github.io/rdf-tests/sparql/sparql11/) | [SPARQL 1.1 HTTP RDF Update](http://www.w3.org/TR/sparql11-http-rdf-update/) | ✖ | http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl |
 | [RDF/XML Syntax Tests](https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/) | [RDF 1.1 XML Syntax](https://www.w3.org/TR/rdf-syntax-grammar/) | [`IParser`](https://github.com/rubensworks/rdf-test-suite.js/blob/master/lib/testcase/rdfsyntax/IParser.ts) | https://w3c.github.io/rdf-tests/rdf/rdf11/rdf-xml/manifest.ttl |

--- a/README.md
+++ b/README.md
@@ -241,7 +241,11 @@ $ rdf-test-suite myengine.js http://w3c.github.io/rdf-tests/sparql/sparql11/mani
   -i '{ "myProperty": "myValue" }'
 ```
 
-The SPARQL 1.1 Service Description tests require the endpoint under test:
+For the SPARQL 1.1 Service Description tests, the runner will call the optional
+`startServiceDescriptionEndpoint` method on an `IQueryEngine`, use the returned
+endpoint URL, and invoke its `close` method after the manifest completes. An explicitly
+configured `serviceDescriptionEndpoint` takes precedence,
+which allows testing an endpoint that is already running:
 
 ```bash
 $ rdf-test-suite myengine.js http://w3c.github.io/rdf-tests/sparql/sparql11/manifest-all.ttl \

--- a/index.ts
+++ b/index.ts
@@ -18,6 +18,7 @@ export * from './lib/testcase/sparql/TestCaseCsvResultFormat';
 export * from './lib/testcase/sparql/TestCaseNegativeSyntax';
 export * from './lib/testcase/sparql/TestCasePositiveSyntax';
 export * from './lib/testcase/sparql/TestCaseQueryEvaluation';
+export * from './lib/testcase/sparql/TestCaseServiceDescription';
 export * from './lib/testcase/sparql/TestCaseUpdateEvaluation';
 export * from './lib/testcase/ITestCase';
 export * from './lib/testcase/ITestCaseHandler';

--- a/lib/TestSuiteRunner.ts
+++ b/lib/TestSuiteRunner.ts
@@ -4,6 +4,7 @@ import { DataFactory } from 'rdf-data-factory';
 import type { IManifest } from './IManifest';
 import { ManifestLoader } from './ManifestLoader';
 import type { ITestCase } from './testcase/ITestCase';
+import type { IQueryEngine } from './testcase/sparql/IQueryEngine';
 import { Util } from './Util';
 import WriteStream = NodeJS.WriteStream;
 import Timeout = NodeJS.Timeout;
@@ -14,6 +15,7 @@ const quad = require('rdf-quad');
 const streamifyArray = require('streamify-array').streamifyArray;
 
 const DF = new DataFactory();
+const SERVICE_DESCRIPTION_SPECIFICATION = 'http://www.w3.org/TR/sparql11-service-description/';
 
 export interface ITestSuiteConfig {
   exitWithStatusCode0: boolean;
@@ -65,12 +67,48 @@ export class TestSuiteRunner {
       if (!manifest.specifications || !manifest.specifications[specification]) {
         return [];
       }
-      await this.runManifestConcrete(manifest.specifications[specification], handler, config, results);
+      await this.runManifestWithEndpoint(manifest.specifications[specification], handler, config, results);
       return results;
     }
 
-    await this.runManifestConcrete(manifest, handler, config, results);
+    await this.runManifestWithEndpoint(manifest, handler, config, results);
     return results;
+  }
+
+  /**
+   * Run a manifest, starting an endpoint if the selected specification requires one.
+   * @param {string} manifest A manifest.
+   * @param handler The handler to run the tests with.
+   * @param config The test suite configuration.
+   * @param {ITestResult[]} results An array to append the test results to.
+   * @return {Promise<void>} A promise resolving when the tests are finished.
+   */
+  private async runManifestWithEndpoint(
+    manifest: IManifest,
+    handler: any,
+    config: ITestSuiteConfig,
+    results: ITestResult[],
+  ): Promise<void> {
+    const engine = <IQueryEngine> handler;
+    const customEngineOptions = <Record<string, unknown>> config.customEngingeOptions;
+    if (config.specification === SERVICE_DESCRIPTION_SPECIFICATION &&
+      !customEngineOptions.serviceDescriptionEndpoint && engine.startServiceDescriptionEndpoint) {
+      const serviceDescription = await engine.startServiceDescriptionEndpoint();
+      try {
+        await this.runManifestConcrete(manifest, handler, {
+          ...config,
+          customEngingeOptions: {
+            ...customEngineOptions,
+            serviceDescriptionEndpoint: serviceDescription.endpoint,
+          },
+        }, results);
+      } finally {
+        await serviceDescription.close();
+      }
+      return;
+    }
+
+    await this.runManifestConcrete(manifest, handler, config, results);
   }
 
   /**

--- a/lib/testcase/TestCaseHandlers.ts
+++ b/lib/testcase/TestCaseHandlers.ts
@@ -9,6 +9,7 @@ import { TestCaseCsvResultFormatHandler } from './sparql/TestCaseCsvResultFormat
 import { TestCaseNegativeSyntaxHandler } from './sparql/TestCaseNegativeSyntax';
 import { TestCasePositiveSyntaxHandler } from './sparql/TestCasePositiveSyntax';
 import { TestCaseQueryEvaluationHandler } from './sparql/TestCaseQueryEvaluation';
+import { TestCaseServiceDescriptionHandler } from './sparql/TestCaseServiceDescription';
 import { TestCaseUpdateEvaluationHandler } from './sparql/TestCaseUpdateEvaluation';
 import { TestCaseUnsupportedHandler } from './TestCaseUnsupported';
 
@@ -39,7 +40,7 @@ module.exports = {
   'http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#CSVResultFormatTest':
     new TestCaseCsvResultFormatHandler(),
   'http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#ServiceDescriptionTest':
-    new TestCaseUnsupportedHandler('sparql:ServiceDescriptionTest'), // TODO: implement
+    new TestCaseServiceDescriptionHandler(),
   'http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#ProtocolTest':
     new TestCaseUnsupportedHandler('sparql:ProtocolTest'), // TODO: implement
   'http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#GraphStoreProtocolTest':

--- a/lib/testcase/sparql/IQueryEngine.ts
+++ b/lib/testcase/sparql/IQueryEngine.ts
@@ -1,12 +1,21 @@
 import type * as RDF from '@rdfjs/types';
 
 /**
+ * A running endpoint for Service Description conformance tests.
+ */
+export interface IServiceDescriptionEndpoint {
+  endpoint: string;
+  close: () => Promise<void>;
+}
+
+/**
  * A query engine handler.
  */
 export interface IQueryEngine {
   parse: (queryString: string, options: Record<string, any>) => Promise<void>;
   query: (data: RDF.Quad[], queryString: string, options: Record<string, any>) => Promise<IQueryResult>;
   queryResultFormat?: (data: RDF.Quad[], queryString: string, mediaType: string, options: Record<string, any>) => Promise<NodeJS.ReadableStream>;
+  startServiceDescriptionEndpoint?: () => Promise<IServiceDescriptionEndpoint>;
 }
 
 /**

--- a/lib/testcase/sparql/TestCaseServiceDescription.ts
+++ b/lib/testcase/sparql/TestCaseServiceDescription.ts
@@ -1,0 +1,143 @@
+import type * as RDF from '@rdfjs/types';
+import { arrayifyStream } from 'arrayify-stream';
+import type { Resource } from 'rdf-object';
+import { ErrorTest } from '../../ErrorTest';
+import { Util } from '../../Util';
+import type { ITestCaseData } from '../ITestCase';
+import type { ITestCaseHandler } from '../ITestCaseHandler';
+import type { IQueryEngine } from './IQueryEngine';
+import type { ITestCaseSparql } from './ITestCaseSparql';
+
+const RDF_TYPE = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type';
+const SD = 'http://www.w3.org/ns/sparql-service-description#';
+
+export interface IServiceDescriptionTestOptions {
+  /** The SPARQL endpoint whose service description is under test. */
+  serviceDescriptionEndpoint?: string;
+}
+
+/**
+ * Test case handler for http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#ServiceDescriptionTest.
+ */
+export class TestCaseServiceDescriptionHandler implements ITestCaseHandler<TestCaseServiceDescription> {
+  public async resourceToTestCase(_resource: Resource, testCaseData: ITestCaseData): Promise<TestCaseServiceDescription> {
+    return new TestCaseServiceDescription(testCaseData);
+  }
+}
+
+export class TestCaseServiceDescription implements ITestCaseSparql {
+  public readonly type = 'sparql';
+  public readonly approval: string;
+  public readonly approvedBy: string;
+  public readonly comment: string;
+  public readonly types: string[];
+  public readonly name: string;
+  public readonly uri: string;
+
+  public constructor(testCaseData: ITestCaseData) {
+    Object.assign(this, testCaseData);
+  }
+
+  public async test(_engine: IQueryEngine, injectArguments: IServiceDescriptionTestOptions): Promise<void> {
+    const endpoint = TestCaseServiceDescription.getEndpoint(injectArguments);
+
+    switch (this.name) {
+      case 'GET on endpoint returns RDF':
+        await TestCaseServiceDescription.getServiceDescription(endpoint);
+        return;
+      case 'Service description contains a matching sd:endpoint triple': {
+        const serviceDescription = await TestCaseServiceDescription.getServiceDescription(endpoint);
+        if (!serviceDescription.some(quad => quad.predicate.value === `${SD}endpoint` &&
+          quad.object.termType === 'NamedNode' && quad.object.value === endpoint)) {
+          throw new ErrorTest(`Service description at ${endpoint} does not contain a matching sd:endpoint triple.`);
+        }
+        return;
+      }
+      case 'Service description conforms to schema': {
+        const serviceDescription = await TestCaseServiceDescription.getServiceDescription(endpoint);
+        TestCaseServiceDescription.validateSchema(serviceDescription, endpoint);
+        return;
+      }
+      default:
+        throw new ErrorTest(`Unsupported SPARQL service-description test: ${this.name}`);
+    }
+  }
+
+  private static getEndpoint(injectArguments: IServiceDescriptionTestOptions): string {
+    const endpoint = injectArguments && injectArguments.serviceDescriptionEndpoint;
+    if (!endpoint) {
+      throw new ErrorTest('Service-description tests require the serviceDescriptionEndpoint option.');
+    }
+    try {
+      const url = new URL(endpoint);
+      if (url.search || url.hash) {
+        throw new Error('The endpoint URL must not contain query parameters or a fragment');
+      }
+    } catch (error) {
+      throw new ErrorTest(`Invalid serviceDescriptionEndpoint: ${(error as Error).message}`);
+    }
+    return endpoint;
+  }
+
+  private static async getServiceDescription(endpoint: string): Promise<RDF.Quad[]> {
+    try {
+      const response = await Util.fetchCached(endpoint, {}, {
+        headers: {
+          accept: 'text/turtle, application/rdf+xml;q=0.9, application/ld+json;q=0.8',
+        },
+        method: 'GET',
+      });
+      const contentType = Util.identifyContentType(response.url, response.headers);
+      return await arrayifyStream(Util.parseRdfRaw(contentType, endpoint, response.body));
+    } catch (error) {
+      throw new ErrorTest(`Could not retrieve an RDF service description from ${endpoint}: ${(error as Error).message}`);
+    }
+  }
+
+  private static validateSchema(serviceDescription: RDF.Quad[], endpoint: string): void {
+    const namedGraphs = new Set<string>();
+    const namedGraphsWithName = new Set<string>();
+    const datasets = new Set<string>();
+    const datasetsWithDefaultGraph = new Set<string>();
+
+    for (const quad of serviceDescription) {
+      const subject = TestCaseServiceDescription.termKey(quad.subject);
+      if (quad.predicate.value === `${SD}endpoint` && quad.object.termType !== 'NamedNode') {
+        throw new ErrorTest(`The sd:endpoint value in the service description at ${endpoint} must be an IRI.`);
+      }
+      if (quad.predicate.value === `${SD}name`) {
+        if (quad.object.termType !== 'NamedNode') {
+          throw new ErrorTest(`The sd:name value in the service description at ${endpoint} must be an IRI.`);
+        }
+        namedGraphsWithName.add(subject);
+      }
+      if (quad.predicate.value === `${SD}namedGraph`) {
+        namedGraphs.add(TestCaseServiceDescription.termKey(quad.object));
+      }
+      if (quad.predicate.value === `${SD}defaultGraph`) {
+        datasetsWithDefaultGraph.add(subject);
+      }
+      if (quad.predicate.value === RDF_TYPE && quad.object.value === `${SD}NamedGraph`) {
+        namedGraphs.add(subject);
+      }
+      if (quad.predicate.value === RDF_TYPE && quad.object.value === `${SD}Dataset`) {
+        datasets.add(subject);
+      }
+    }
+
+    for (const namedGraph of namedGraphs) {
+      if (!namedGraphsWithName.has(namedGraph)) {
+        throw new ErrorTest(`Each sd:NamedGraph in the service description at ${endpoint} must have an sd:name.`);
+      }
+    }
+    for (const dataset of datasets) {
+      if (!datasetsWithDefaultGraph.has(dataset)) {
+        throw new ErrorTest(`Each sd:Dataset in the service description at ${endpoint} must have an sd:defaultGraph.`);
+      }
+    }
+  }
+
+  private static termKey(term: RDF.Term): string {
+    return `${term.termType}:${term.value}`;
+  }
+}

--- a/lib/testcase/sparql/TestCaseServiceDescription.ts
+++ b/lib/testcase/sparql/TestCaseServiceDescription.ts
@@ -66,7 +66,7 @@ export class TestCaseServiceDescription implements ITestCaseSparql {
   private static getEndpoint(injectArguments: IServiceDescriptionTestOptions): string {
     const endpoint = injectArguments && injectArguments.serviceDescriptionEndpoint;
     if (!endpoint) {
-      throw new ErrorTest('Service-description tests require the serviceDescriptionEndpoint option.');
+      throw new ErrorTest('Service-description tests require an endpoint from startServiceDescriptionEndpoint or the serviceDescriptionEndpoint option.');
     }
     try {
       const url = new URL(endpoint);

--- a/test/TestSuiteRunner-test.ts
+++ b/test/TestSuiteRunner-test.ts
@@ -51,6 +51,16 @@ const timeOutMockTest1 = {
   },
   uri: 'http://ex.org/timeout1',
 };
+const serviceDescriptionSpecification = 'http://www.w3.org/TR/sparql11-service-description/';
+let serviceDescriptionOptions: Record<string, unknown> | undefined;
+const serviceDescriptionMockTest = {
+  name: 'Service description',
+  test: (_handler: unknown, options: Record<string, unknown>) => {
+    serviceDescriptionOptions = options;
+    return Promise.resolve();
+  },
+  uri: 'http://ex.org/service-description',
+};
 
 const defaultConfig: ITestSuiteConfig = {
   customEngingeOptions: {},
@@ -111,6 +121,17 @@ jest.mock<typeof import('../lib/ManifestLoader')>('../lib/ManifestLoader', () =>
             uri: manifestUrl,
           });
         }
+        if (manifestUrl === 'validservicedescription') {
+          return Promise.resolve({
+            specifications: {
+              [serviceDescriptionSpecification]: {
+                testEntries: [ serviceDescriptionMockTest ],
+                uri: manifestUrl,
+              },
+            },
+            uri: manifestUrl,
+          });
+        }
         if (manifestUrl === 'timeout') {
           return Promise.resolve({
             testEntries: [ timeOutMockTest1 ],
@@ -148,6 +169,7 @@ describe('TestSuiteRunner', () => {
   beforeEach(() => {
     runner = new TestSuiteRunner();
     handler = () => true;
+    serviceDescriptionOptions = undefined;
   });
 
   describe('fromUrlToMappingString', () => {
@@ -244,6 +266,40 @@ describe('TestSuiteRunner', () => {
           test: mockTest3,
         },
       ]);
+    });
+
+    it('should start and close an endpoint for the service-description specification', async() => {
+      const serviceDescriptionEndpoint = {
+        close: jest.fn().mockResolvedValue(undefined),
+        endpoint: 'http://example.org/sparql',
+      };
+      handler = {
+        startServiceDescriptionEndpoint: jest.fn().mockResolvedValue(serviceDescriptionEndpoint),
+      };
+      const config: ITestSuiteConfig = { ...defaultConfig, specification: serviceDescriptionSpecification };
+
+      await expect(runner.runManifest('validservicedescription', handler, config)).resolves.toHaveLength(1);
+      expect(handler.startServiceDescriptionEndpoint).toHaveBeenCalledTimes(1);
+      expect(serviceDescriptionEndpoint.close).toHaveBeenCalledTimes(1);
+      expect(serviceDescriptionOptions).toEqual({ serviceDescriptionEndpoint: 'http://example.org/sparql' });
+    });
+
+    it('should use a configured service-description endpoint without starting one', async() => {
+      handler = {
+        startServiceDescriptionEndpoint: jest.fn().mockResolvedValue({
+          close: jest.fn().mockResolvedValue(undefined),
+          endpoint: 'http://example.org/started',
+        }),
+      };
+      const config: ITestSuiteConfig = {
+        ...defaultConfig,
+        customEngingeOptions: { serviceDescriptionEndpoint: 'http://example.org/configured' },
+        specification: serviceDescriptionSpecification,
+      };
+
+      await expect(runner.runManifest('validservicedescription', handler, config)).resolves.toHaveLength(1);
+      expect(handler.startServiceDescriptionEndpoint).not.toHaveBeenCalled();
+      expect(serviceDescriptionOptions).toEqual({ serviceDescriptionEndpoint: 'http://example.org/configured' });
     });
 
     it('should handle testcases that time out', (next) => {

--- a/test/e2e-test.ts
+++ b/test/e2e-test.ts
@@ -116,7 +116,8 @@ describe('e2e tests on the test suite runner', () => {
       'http://www.w3.org/TR/sparql11-results-json/': 4,
       // Federated spec tries to do external queries
       // "http://www.w3.org/TR/sparql11-federated-query/",
-      'http://www.w3.org/TR/sparql11-service-description/': 3,
+      // Service-description tests require a separately configured HTTP endpoint
+      // "http://www.w3.org/TR/sparql11-service-description/",
       'http://www.w3.org/TR/sparql11-protocol/': 34,
       'http://www.w3.org/TR/sparql11-http-rdf-update/': 12,
     })) {
@@ -134,7 +135,7 @@ describe('e2e tests on the test suite runner', () => {
         }
 
         // Unsupported test can be skipped
-        if (!spec.includes('tsv') && !spec.includes('rdf-update') && !spec.includes('service-description') && !spec.includes('protocol')) {
+        if (!spec.includes('rdf-update') && !spec.includes('protocol')) {
           expect(skipped).toBe(0);
         }
 

--- a/test/testcase/sparql/TestCaseServiceDescription-test.ts
+++ b/test/testcase/sparql/TestCaseServiceDescription-test.ts
@@ -49,7 +49,7 @@ describe('TestCaseServiceDescriptionHandler', () => {
   describe('#test', () => {
     it('should require an endpoint', async() => {
       const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('GET on endpoint returns RDF'));
-      await expect(testCase.test(<any> {}, {})).rejects.toThrow('require the serviceDescriptionEndpoint option');
+      await expect(testCase.test(<any> {}, {})).rejects.toThrow('require an endpoint from startServiceDescriptionEndpoint');
     });
 
     it('should reject an endpoint with query parameters', async() => {

--- a/test/testcase/sparql/TestCaseServiceDescription-test.ts
+++ b/test/testcase/sparql/TestCaseServiceDescription-test.ts
@@ -1,0 +1,134 @@
+import { TestCaseServiceDescription, TestCaseServiceDescriptionHandler } from '../../../lib/testcase/sparql/TestCaseServiceDescription';
+
+const endpoint = 'http://example.org/sparql';
+let contentType: string;
+let serviceDescription: string;
+
+// Mock fetch
+(<any> globalThis).fetch = (url: string) => {
+  if (url !== endpoint) {
+    return Promise.reject(new Error(`Fetch error for ${url}`));
+  }
+  return Promise.resolve(new Response(serviceDescription, <any> {
+    headers: new Headers({ 'Content-Type': contentType }),
+    status: 200,
+  }));
+};
+
+describe('TestCaseServiceDescriptionHandler', () => {
+  const handler = new TestCaseServiceDescriptionHandler();
+
+  function testCaseData(name: string) {
+    return {
+      approval: null,
+      approvedBy: null,
+      comment: null,
+      name,
+      types: [ 'http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#ServiceDescriptionTest' ],
+      uri: `http://example.org/${name}`,
+    };
+  }
+
+  beforeEach(() => {
+    contentType = 'text/turtle';
+    serviceDescription = `@prefix sd: <http://www.w3.org/ns/sparql-service-description#> .
+[] a sd:Service ;
+  sd:endpoint <${endpoint}> .`;
+  });
+
+  describe('#resourceToTestCase', () => {
+    it('should produce a TestCaseServiceDescription', async() => {
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('GET on endpoint returns RDF'));
+
+      expect(testCase).toBeInstanceOf(TestCaseServiceDescription);
+      expect(testCase.type).toBe('sparql');
+      expect(testCase.name).toBe('GET on endpoint returns RDF');
+    });
+  });
+
+  describe('#test', () => {
+    it('should require an endpoint', async() => {
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('GET on endpoint returns RDF'));
+      await expect(testCase.test(<any> {}, {})).rejects.toThrow('require the serviceDescriptionEndpoint option');
+    });
+
+    it('should reject an endpoint with query parameters', async() => {
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('GET on endpoint returns RDF'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: `${endpoint}?query={}` }))
+        .rejects.toThrow('must not contain query parameters');
+    });
+
+    it('should validate that the endpoint returns RDF', async() => {
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('GET on endpoint returns RDF'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).resolves.toBeUndefined();
+    });
+
+    it('should reject an endpoint that does not return RDF', async() => {
+      contentType = 'text/html';
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('GET on endpoint returns RDF'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('Could not retrieve an RDF service description');
+    });
+
+    it('should validate the matching sd:endpoint triple', async() => {
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description contains a matching sd:endpoint triple'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).resolves.toBeUndefined();
+    });
+
+    it('should reject a non-matching sd:endpoint triple', async() => {
+      serviceDescription = serviceDescription.replace(endpoint, 'http://example.org/other');
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description contains a matching sd:endpoint triple'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('does not contain a matching sd:endpoint triple');
+    });
+
+    it('should reject an sd:endpoint that is not an IRI', async() => {
+      serviceDescription = serviceDescription.replace(`<${endpoint}>`, `"${endpoint}"`);
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description contains a matching sd:endpoint triple'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('does not contain a matching sd:endpoint triple');
+    });
+
+    it('should validate the service-description vocabulary', async() => {
+      serviceDescription += `
+[] a sd:Dataset ;
+  sd:defaultGraph [] ;
+  sd:namedGraph [ sd:name <http://example.org/graph> ] .`;
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description conforms to schema'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).resolves.toBeUndefined();
+    });
+
+    it('should reject a named graph without an sd:name', async() => {
+      serviceDescription += '\n[] sd:namedGraph [] .';
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description conforms to schema'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('must have an sd:name');
+    });
+
+    it('should reject an sd:name that is not an IRI', async() => {
+      serviceDescription += '\n[] sd:namedGraph [ sd:name "named graph" ] .';
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description conforms to schema'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('sd:name value');
+    });
+
+    it('should fail schema validation if sd:endpoint is not an IRI', async() => {
+      serviceDescription = serviceDescription.replace(`<${endpoint}>`, `"${endpoint}"`);
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description conforms to schema'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('sd:endpoint value');
+    });
+
+    it('should reject an sd:NamedGraph without an sd:name', async() => {
+      serviceDescription += '\n[] a sd:NamedGraph .';
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description conforms to schema'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('must have an sd:name');
+    });
+
+    it('should reject a dataset without an sd:defaultGraph', async() => {
+      serviceDescription += '\n[] a sd:Dataset .';
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Service description conforms to schema'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint })).rejects.toThrow('must have an sd:defaultGraph');
+    });
+
+    it('should reject an unknown test', async() => {
+      const testCase = await handler.resourceToTestCase(<any> {}, testCaseData('Unknown service-description test'));
+      await expect(testCase.test(<any> {}, { serviceDescriptionEndpoint: endpoint }))
+        .rejects.toThrow('Unsupported SPARQL service-description test');
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a `TestCaseServiceDescriptionHandler` for the three SPARQL 1.1 Service Description conformance cases.

Refs https://github.com/comunica/comunica/issues/721