### PR TITLE
Pass `checkOrder` to `engine.query`

### DIFF
--- a/lib/testcase/sparql/TestCaseQueryEvaluation.ts
+++ b/lib/testcase/sparql/TestCaseQueryEvaluation.ts
@@ -418,7 +418,17 @@ export class TestCaseQueryEvaluation implements ITestCaseSparql {
   }
 
   public async test(engine: IQueryEngine, injectArguments: any): Promise<void> {
-    const result: IQueryResult = await engine.query(this.queryData, this.queryString, { baseIRI: this.baseIRI, ...injectArguments });
+    const result: IQueryResult = await engine.query(
+      this.queryData,
+      this.queryString,
+      {
+        baseIRI: this.baseIRI,
+        checkOrder: this.queryResult.type === 'bindings' ?
+          this.queryResult.checkOrder :
+          false,
+        ...injectArguments,
+      },
+    );
     if (!this.queryResult.equals(result, this.laxCardinality)) {
       throw new ErrorTest(`Invalid query evaluation
 


### PR DESCRIPTION
The engine needs to pass `checkOrder` to `new RdfTestSuite.QueryResultBindings` for the engine result. However the engine had no way of calculating this `checkOrder` since it's reliant on the result set, which is why it's now passed to the engine. It's slightly cursed, but it's minimal and it works.

This was needed for https://github.com/comunica/comunica/pull/1739.