### PR TITLE
remove normalizeBaseUrl from the data graph links

### DIFF
--- a/lib/Util.ts
+++ b/lib/Util.ts
@@ -48,6 +48,7 @@ export class Util {
       'unknown';
   }
 
+  // TODO: remove in the next major release
   /**
    * Convert https to http
    * @param {string} url A URL.

--- a/lib/testcase/sparql/TestCaseQueryEvaluation.ts
+++ b/lib/testcase/sparql/TestCaseQueryEvaluation.ts
@@ -302,12 +302,12 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
       if (graphData.property.graph) {
         queryDataLinks.push({
           dataUri: graphData.property.graph.value,
-          dataGraph: DF.namedNode(Util.normalizeBaseUrl(graphData.property.label.value)),
+          dataGraph: DF.namedNode(graphData.property.label.value),
         });
       } else {
         queryDataLinks.push({
           dataUri: graphData.value,
-          dataGraph: DF.namedNode(Util.normalizeBaseUrl(graphData.value)),
+          dataGraph: DF.namedNode(graphData.value),
         });
       }
     }
@@ -322,7 +322,7 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
   public static async resolveQueryDataLinks(queryDataLinks: IQueryDataLink[], options?: IFetchOptions): Promise<RDF.Quad[]> {
     let queryData: RDF.Quad[] = [];
     for (const queryDataLink of queryDataLinks) {
-      let queryDataThis: RDF.Quad[] = await arrayifyStream((await Util.fetchRdf(queryDataLink.dataUri, { ...options, normalizeUrl: true }))[1]);
+      let queryDataThis: RDF.Quad[] = await arrayifyStream((await Util.fetchRdf(queryDataLink.dataUri, options))[1]);
       if (queryDataLink.dataGraph) {
         queryDataThis = queryDataThis.map(quad => mapTerms(quad, (value: RDF.Term, key: QuadTermName) => key === 'graph' ? queryDataLink.dataGraph : value));
       }


### PR DESCRIPTION
This fixes a SPARQL 1.0 spec tests issue where for graphs a https IRI is expected, but http is received. Part of https://github.com/comunica/comunica/issues/1736.

The issue was related to the migration of http://www.w3.org/ to https://www.w3c.github.io/, due to the github pages hosting, every http fetch is redirected to https.

This makes `Util.normalizeBaseUrl` unneccesary and it breaks a few graph SPARQL 1.0 spec tests. This solution has minimal changes to only fix these failing tests. But the `Util.normalizeBaseUrl` can also be entirely removed, it doesn't break any other tests, should I do this or not?