### PR TITLE
Add support for ASK queries in dawg tests

### DIFF
--- a/lib/testcase/sparql/TestCaseQueryEvaluation.ts
+++ b/lib/testcase/sparql/TestCaseQueryEvaluation.ts
@@ -14,7 +14,7 @@ import type { IFetchOptions, IFetchResponse } from '../../Util';
 import { Util } from '../../Util';
 import type { ITestCaseData } from '../ITestCase';
 import type { ITestCaseHandler } from '../ITestCaseHandler';
-import type { IQueryEngine, IQueryResult, IQueryResultBindings } from './IQueryEngine';
+import type { IQueryEngine, IQueryResult, IQueryResultBindings, IQueryResultBoolean } from './IQueryEngine';
 import type { ITestCaseSparql } from './ITestCaseSparql';
 import { QueryResultBindings } from './QueryResultBindings';
 import { QueryResultBoolean } from './QueryResultBoolean';
@@ -131,9 +131,14 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
    * Parses query results in the DAWG vocabulary.
    * https://www.w3.org/2001/sw/DataAccess/tests/test-dawg.n3
    * @param {Quad[]} quads An array of quads.
-   * @return {Promise<IQueryResultBindings>} A promise resolving to a bindings results object.
+   * @return {Promise<IQueryResultBindings | IQueryResultBoolean>} A promise resolving to a bindings or boolean results object.
    */
-  public static async parseDawgResultSet(quads: RDF.Quad[]): Promise<IQueryResultBindings> {
+  public static async parseDawgResultSet(quads: RDF.Quad[]): Promise<IQueryResultBindings | IQueryResultBoolean> {
+    // Check for a boolean result (ASK query)
+    if (quads[1] && quads[1].predicate.value === 'http://www.w3.org/2001/sw/DataAccess/tests/result-set#boolean') {
+      return new QueryResultBoolean(quads[1].object.value === 'true');
+    }
+
     // Construct resources for easier interpretation of the bindings
     const objectLoader = new RdfObjectLoader({
       context: {

--- a/test/testcase/sparql/QueryResultBoolean-test.ts
+++ b/test/testcase/sparql/QueryResultBoolean-test.ts
@@ -1,8 +1,8 @@
 import { QueryResultBoolean } from '../../../lib/testcase/sparql/QueryResultBoolean';
 
 describe('QueryResultBoolean', () => {
-  let booleanTrue;
-  let booleanFalse;
+  let booleanTrue: QueryResultBoolean;
+  let booleanFalse: QueryResultBoolean;
 
   beforeEach(() => {
     booleanTrue = new QueryResultBoolean(true);

--- a/test/testcase/sparql/TestCaseQueryEvaluation-test.ts
+++ b/test/testcase/sparql/TestCaseQueryEvaluation-test.ts
@@ -356,6 +356,16 @@ describe('TestCaseQueryEvaluationHandler', () => {
       });
     });
 
+    it('should resolve on an array with a boolean result', async() => {
+      return expect(TestCaseQueryEvaluationHandler.parseDawgResultSet([
+        quad('_:b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2001/sw/DataAccess/tests/result-set#ResultSet'),
+        quad('_:b', 'http://www.w3.org/2001/sw/DataAccess/tests/result-set#boolean', '"true"'),
+      ])).resolves.toEqual({
+        type: 'boolean',
+        value: true,
+      });
+    });
+
     it('should resolve on an array with a non-empty result set with variables', async() => {
       return expect(TestCaseQueryEvaluationHandler.parseDawgResultSet([
         quad('_:b', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#type', 'http://www.w3.org/2001/sw/DataAccess/tests/result-set#ResultSet'),


### PR DESCRIPTION
This support was necessary for the [type promotion spec tests of SPARQL 1.0](https://w3c.github.io/rdf-tests/sparql/sparql10/type-promotion/index.html). The result set got parsed as a `QueryResultBindings` while it should've been a `QueryResultBooleans`.