### PR TITLE
Fixed a bug where a REDUCED test would fail even though the result is correct

### DIFF
--- a/lib/testcase/sparql/QueryResultBindings.ts
+++ b/lib/testcase/sparql/QueryResultBindings.ts
@@ -69,7 +69,7 @@ export class QueryResultBindings implements IQueryResultBindings {
     const hash: Record<string, number> = {};
     for (const b of bindings) {
       const bHash: Record<string, string> = {};
-      for (const variable in b) {
+      for (const variable of Object.keys(b).sort()) {
         bHash[variable] = QueryResultBindings.serializeTerm(b[variable], blankNodeCounters);
       }
       const bString: string = JSON.stringify(bHash);


### PR DESCRIPTION
Because `hashBindingsCount` didn't sort the variables, the lax equality would non-rightfully return false on line 101 of `QueryResultBindings`.

This was the issue for the [`reduced-1` test of SPARQL 1.0](https://w3c.github.io/rdf-tests/sparql/sparql10/reduced/index.html#reduced-1): 
```js
{"?s":"http://example/x1","?o":"abc"},{"?s":"http://example/x2","?o":"abc"} !==
{"?o":"abc","?s":"http://example/x1"},{"?o":"abc","?s":"http://example/x2"}
```