### PR TITLE
Remove `normalizeBaseUrl` from baseIRI

### DIFF
--- a/lib/testcase/sparql/TestCaseQueryEvaluation.ts
+++ b/lib/testcase/sparql/TestCaseQueryEvaluation.ts
@@ -365,7 +365,7 @@ export class TestCaseQueryEvaluationHandler implements ITestCaseHandler<TestCase
     return new TestCaseQueryEvaluation(
       testCaseData,
       {
-        baseIRI: Util.normalizeBaseUrl(action.property.query.value),
+        baseIRI: action.property.query.value,
         queryDataLinks,
         laxCardinality,
         queryData,


### PR DESCRIPTION
The previous removal wasn't enough, I had to remove another `normalizeBaseUrl` for dataset graphs: https://github.com/comunica/comunica/pull/1746.