### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "jest-rdf": "^2.0.0",
     "manual-git-changelog": "^1.0.1",
     "pre-commit": "^2.0.0",
-    "rdf-parse": "^4.0.0",
+    "rdf-parse": "^5.0.0",
     "rimraf": "^6.0.0",
     "streamify-array": "^2.0.0",
     "ts-jest": "^29.0.0",

--- a/package.json
+++ b/package.json
@@ -117,8 +117,8 @@
     "streamify-string": "^1.0.1"
   },
   "devDependencies": {
-    "@comunica/actor-http-proxy": "^4.0.2",
-    "@comunica/query-sparql": "^4.0.2",
+    "@comunica/actor-http-proxy": "^5.0.0",
+    "@comunica/query-sparql": "^5.0.0",
     "@rubensworks/eslint-config": "^3.1.0",
     "@types/jest": "^30.0.0",
     "@types/papaparse": "^5.5.2",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "cross-fetch": "^4.0.0",
     "is-stream": "^2.0.0",
     "json-stable-stringify": "^1.0.1",
+    "jsonld-context-parser": "^3.1.0",
     "jsonld-streaming-parser": "^5.0.0",
     "log-symbols": "^4.0.0",
     "minimist": "^1.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8387,17 +8387,7 @@ jsonld-context-parser@^2.2.2, jsonld-context-parser@^2.4.0:
     http-link-header "^1.0.2"
     relative-to-absolute-iri "^1.0.5"
 
-jsonld-context-parser@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-3.0.0.tgz#43992862fc3eabcee9940cf4c44bb2b0dbe2542c"
-  integrity sha512-Kg6TVtBUdIm057ht/8WNhM9BROt+BeYaDGXbzrKaa3xA99csee+CsD8IMCTizRgzoO8PIzvzcxxCoRvpq1xNQw==
-  dependencies:
-    "@types/http-link-header" "^1.0.1"
-    "@types/node" "^18.0.0"
-    http-link-header "^1.0.2"
-    relative-to-absolute-iri "^1.0.5"
-
-jsonld-context-parser@^3.1.0:
+jsonld-context-parser@^3.0.0, jsonld-context-parser@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/jsonld-context-parser/-/jsonld-context-parser-3.1.0.tgz#208249ab0e412c16e89788738e542b84d0d26041"
   integrity sha512-BfgNJ/t9jjK7Lun9XRCJM6YeNqDk8B6/lg+KS8rzhXAOtS0FvoClSmtLvF24V1M2CDYRy2LcEBt0ilxqSX93WA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -504,6 +504,14 @@
     "@comunica/core" "^4.0.2"
     "@comunica/types" "^4.0.2"
 
+"@comunica/actor-abstract-mediatyped@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.3.0.tgz#fa319eb8c14479848a7db590be822528e2a37735"
+  integrity sha512-60+GYULL9d/jfsTsGodLwPTIZvlDeqLZwtYSaFbMV9ykzaZs5AJp7LDyA5DeNUBPN228fty0jX2FlAXGf7ZGdg==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
 "@comunica/actor-abstract-parse@^2.10.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-2.10.0.tgz#438c570f9c40e80eab86de95d456ff4e257e4f98"
@@ -520,962 +528,975 @@
     "@comunica/core" "^4.0.2"
     readable-stream "^4.5.2"
 
-"@comunica/actor-abstract-path@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-4.0.2.tgz#af44290eddfc18ecae7f358774ed4b8446493b6b"
-  integrity sha512-kmlE1e/3xxbBsvG2ZVoGNrOLIKorLDg3KpGVLSmjPHF2bFh/iU1A9MXKulsvz6FKcXQwCDnlLTKEM5TfQkj4ow==
+"@comunica/actor-abstract-parse@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-5.3.0.tgz#a9cc96c9eae021d85ca9be8dcdbaedb710a69d60"
+  integrity sha512-qh+VuBpMkseEcoRaFjEw5UoMC6bO/45/Q0ZBdwEI3GAsNJhgMaiLQWVEvyBq0fBsQymW7HniZlZcDzuxoUIr5g==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/core" "^5.3.0"
+    readable-stream "^4.7.0"
 
-"@comunica/actor-bindings-aggregator-factory-average@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-4.0.2.tgz#cc050f3d56320cc0b232539cbb62c6ebb9b18e3b"
-  integrity sha512-oCdRVBYucSl6jN+GIGtIpU2jjJzVWFe6sdcPbrXapnqqDFHAnkkYE+CVNBddQ714J+uK0/luOY+MSSt+mJagYA==
+"@comunica/actor-abstract-path@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-path/-/actor-abstract-path-5.3.0.tgz#6b4ff53d6fc219410f3719b1bae0148938eac166"
+  integrity sha512-exK0EcWyscuu7psF2U4Cm4iAlOW1fWRAqCZLJo0I7v+8hXtCHTLx2P2bV2LFUvt8Kry4ATzUrrm019RX4b0+hg==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-bindings-aggregator-factory-count@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-4.0.2.tgz#b280882b9e6c684e89fa0c69ccf7d12597ae3b5a"
-  integrity sha512-KgX3ADbxRqjFIGt97nmtYVeW8S9skcsg9sBWU19A5ubmt9e9WRFxUfj0zsPiueqe7nq+WMzd2RKkRs6GNh+8pw==
+"@comunica/actor-bindings-aggregator-factory-average@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-average/-/actor-bindings-aggregator-factory-average-5.3.0.tgz#d3216e9b9424f297bc4956824630af5d8bd6e1ec"
+  integrity sha512-dsTR0dQPnisdX9xklFz/WcyA60t9SpDef1Bzryl/cETr9pnnD+HMF3aDZYvmfINUp3YjRP8cxJeWVHPv+kyluA==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.2.0"
-
-"@comunica/actor-bindings-aggregator-factory-group-concat@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-4.0.2.tgz#2e4c7baaa6ffc9c655b20de7e39d59f6a8d623c4"
-  integrity sha512-zUXgDrbI/0zopjCpoxlWCz0EEezqoTOoM1JqBGb29zTuYMcn9o+QswAyJTlbgBGjjIHW89xXCKUqPygOPf9qXg==
-  dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-max@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-4.0.2.tgz#e93c611a5ffb9304f8c68097abd1766f2c7fe10d"
-  integrity sha512-QpX/YnIh8etnuWvNZTVo+59yRDMBFRIdyiR+IR5/yOk6mNshWKnHQDmOHog4AR2g5WLNbRO4QvEBviubFCxBLQ==
+"@comunica/actor-bindings-aggregator-factory-count@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-count/-/actor-bindings-aggregator-factory-count-5.3.0.tgz#534a56ad60e1e080330106e9f1a5c5d2618d977b"
+  integrity sha512-tLdoFX2poA0tKXXGAREMps0aI3x+MNEGbRftPFD24NbMybmCjSWyN0L3Az29eoWL4zIkmhMK9S/xaguB4k85pg==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-min@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-4.0.2.tgz#dc03435cb48a392c73a9927cdf3be56ef21235d5"
-  integrity sha512-09UZnVICC5Sh3/B1Lqoe1/nC0Yhvj1kMd4emDa686Vhd6knBqkU364kltT4ot7zItEo/HKwEOnn13CCnNlphsQ==
+"@comunica/actor-bindings-aggregator-factory-group-concat@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-group-concat/-/actor-bindings-aggregator-factory-group-concat-5.3.0.tgz#5a1fad3dae135146c6cb9ce42cd5c4492f6110fa"
+  integrity sha512-dypWIfRmvr99qu/0MQWE0oCuhHRt/6NT68c/wctO1ZDb9WPzO24XsjYNcQHPer69uoZIY8s61/V3MJ4/we3dFQ==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-sample@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-4.0.2.tgz#8c68957c505f6706e48edb5accc3c3b9242b8788"
-  integrity sha512-o9LGwVNtUH94X/8aen1sj7R38Q/3MkED6kjut09OegyYKXNFRL3kmF3krgZIe0go79GTd1F+qUTo4R7pmoHzYg==
+"@comunica/actor-bindings-aggregator-factory-max@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-max/-/actor-bindings-aggregator-factory-max-5.3.0.tgz#491a02b69e422b7cd8b1cf5d207b495c5313fd47"
+  integrity sha512-FlOY4BrSp0uhLCwEh4cHsFFwsiulr3CIfJ+r010WA/n+qwSSp/iGH9s4zmfbqC1tBRrFK9alCdxQJr0BY17MDA==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-sum@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-4.0.2.tgz#1014500bb362d1a4c85c4c26484b8d82b78493cb"
-  integrity sha512-uwZPG1zAsjOkVYeKFQceyDmQjJkXClvHzRxPDQkVhuxyJvD8BxDQ4psH9kAOiOc1EyGAQB36IhoE3r1RaKF06A==
+"@comunica/actor-bindings-aggregator-factory-min@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-min/-/actor-bindings-aggregator-factory-min-5.3.0.tgz#9cbb45fca6a47453bf6ebe6af7832fca2c8255c4"
+  integrity sha512-9UGaNaDab76Po3XFOIIZm2RCZDc7Gbwcrr+2hgG5DuJjtxBwl7z3pMkHFYjaBikF9GFaZ1VjT0sW51S80Y8rbg==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/actor-bindings-aggregator-factory-wildcard-count@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-4.0.2.tgz#6625171025d7b4a6943096d3c5c874a67f0ed721"
-  integrity sha512-P4ixEDCtTH8+OFrHHCnDnQeZGGY8Q0fIi71cHcRi65kvYuHis/U+Au2Hc+6C+ljTr4B8D+hpEW/0LP3UlTeweQ==
+"@comunica/actor-bindings-aggregator-factory-sample@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-sample/-/actor-bindings-aggregator-factory-sample-5.3.0.tgz#4c0f92b2ae8a03a8103275b052ed37009ae42521"
+  integrity sha512-ib4MpjNKyGRdKwNjRjoP/Chf5ba8hqDq/LTac8bry405EeimiCZvOmbWa6QQwIvkAtfjMmeydCclMmdnjS8hNQ==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-string "^1.6.3"
 
-"@comunica/actor-context-preprocess-convert-shortcuts@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-4.0.2.tgz#6a423aaccd036181f02222721f718604cf13fbc8"
-  integrity sha512-GDQyVwzB/zB7lXmbHKcstDSExCPZqj9nymht5Y9NYU8HiiPOA+GM70EOsKW1WBVMtvNohN2gcTdjg8zSYAvuUg==
+"@comunica/actor-bindings-aggregator-factory-sum@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-sum/-/actor-bindings-aggregator-factory-sum-5.3.0.tgz#821e5085894d76a5a0fe54f15782fca30f55ebb7"
+  integrity sha512-KWS4sYMvYGEhuxVD12OmxGGf7ZU6vV9u4kdq8v9OTTKiEb3YzaQa7IlzsF94qHoek1xH5xp+N7dxaOG+H3z87w==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/actor-context-preprocess-query-source-identify@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-query-source-identify/-/actor-context-preprocess-query-source-identify-4.0.2.tgz#08d133bee3bf9cfacde156926f302fe38e845faa"
-  integrity sha512-NqV4g7bVbHFgOzRk4mmBCmH7/xVpccHCPh0wldydd0hEcOQPBxsZjedKPqm13495+AFdGrv0xHdIl1qJO6s9Yw==
-  dependencies:
-    "@comunica/bus-context-preprocess" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    lru-cache "^10.0.0"
-
-"@comunica/actor-context-preprocess-query-source-skolemize@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-query-source-skolemize/-/actor-context-preprocess-query-source-skolemize-4.0.2.tgz#57898593d5155a10e1ed65c8ecd3adab4575daf6"
-  integrity sha512-YycNbqmAQW0LxYI9ICK5f4HGZK6duIYVtQ36pZL75DreIbTs7ny8uQtSvusH7gGaaLZYrdAOXOqhdhz4MOWdPQ==
-  dependencies:
-    "@comunica/bus-context-preprocess" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-data-factory" "^4.0.1"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
 
-"@comunica/actor-context-preprocess-set-defaults@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-4.0.2.tgz#04c779013d4c379664fc4ead487eec06781ed061"
-  integrity sha512-ypCh92zG0G/zjFkl+PwkN+ks9ZWLoCPq6fkJbGSVsECe466pJamTx0hKpjY+kYmdzmpbELV2RYxxzx74soHjBg==
+"@comunica/actor-bindings-aggregator-factory-wildcard-count@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-bindings-aggregator-factory-wildcard-count/-/actor-bindings-aggregator-factory-wildcard-count-5.3.0.tgz#6b1cd44a9e7fbf29d554dba844a3085b2dcb005a"
+  integrity sha512-BlZLzCTT/FoMCLS+iGxRf0C3tNDjAoO6/ZcT+H0U+DZ/adhpcw6h90FsLKeolW7tSRVUHNV8BJN4UcLE4x9Czg==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.2"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-context-preprocess-source-to-destination@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-4.0.2.tgz#8c9b199f010e0088e6b4ce46ce60834127d2d066"
-  integrity sha512-Qs8Pptq1xuk9uKY/QIN8lrlvtLJRQ0FT5oDauYUZpO095bzkzpuSEgG4mKNMw3UJKgevIfS9sqmHOmHiOWWqNA==
+"@comunica/actor-context-preprocess-convert-shortcuts@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-convert-shortcuts/-/actor-context-preprocess-convert-shortcuts-5.3.0.tgz#e4ea2ef3ee3edf5a7a6028c47467020015150d13"
+  integrity sha512-Jb17oQjiZrtvWcEfIWlzb7bVHWq0Buxl0YKj+Lpdd8yJMf2euRo7yW84CK0SWtcMa3zmWRR6iz11AVwoAxwvcg==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-context-preprocess" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/actor-dereference-fallback@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-4.0.2.tgz#85ee0072035982b04eea2899b9a84d4721799eb4"
-  integrity sha512-0mOzPz+8UfWL82sHmkGqzp9Hs+MCwZ5zZBDfbQRPTHDG/2DuZ/bruBHK2S88SJ2cGaOla3uSO9vMdu9oUJou6g==
+"@comunica/actor-context-preprocess-set-defaults@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-set-defaults/-/actor-context-preprocess-set-defaults-5.3.0.tgz#b4769eaa8fae132b246772afa8db270520b6b35b"
+  integrity sha512-XUuCgi3pI3A+WK1f4IaL+EGKf+LRk8Tyh1W4f7l/66D7YhU7zT3dpSHQ0czywDgZGD8y8BB5avLHF/NlufEQHQ==
   dependencies:
-    "@comunica/bus-dereference" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-context-preprocess" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    rdf-data-factory "^2.0.0"
 
-"@comunica/actor-dereference-http@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-4.0.2.tgz#9d66c73e44ff81737d7b67ac152b323f6a58cd68"
-  integrity sha512-z9tUI6Lohb8zz0s8MTW0v7tLJVc5B0epbDLzfHdVqS8VjZDjtEHz8P8n/FHEeNvsy0NASye/ISMd+RZnUOJQEw==
+"@comunica/actor-context-preprocess-source-to-destination@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-context-preprocess-source-to-destination/-/actor-context-preprocess-source-to-destination-5.3.0.tgz#dc4dc79dbc33bb3136302384e3bfab937b9b63da"
+  integrity sha512-SqlOUs6WiTg2/bGuU7nJdaz/YAZD/yInEsJ1yBXZuuZtgyLsbuFIyIkzce4Jc6WmHvyUklabRVygtVv1ToBAzQ==
   dependencies:
-    "@comunica/bus-dereference" "^4.0.2"
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-context-preprocess" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/actor-dereference-fallback@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-fallback/-/actor-dereference-fallback-5.3.0.tgz#25e01ec4aa0b894dfab1841b59eed05e40491480"
+  integrity sha512-594T3XjvhF58zkSjGkZOaZ7+tGMrJql8nw4ganV5UQ92puweuCcU9heusdgFUfBWA0kVqBMYoE3GOyoBajxkag==
+  dependencies:
+    "@comunica/bus-dereference" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-dereference-http@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-http/-/actor-dereference-http-5.3.0.tgz#f372856062adcf6eb34372076c497483e713b4c4"
+  integrity sha512-aL5VFnIV7X+SL58iJvAySwzvHpFvuUKdUNv78s/S09BCEa+0BZSEDHKFjI3g6DsEx53PZLF0/KGpZa+OQcuFuA==
+  dependencies:
+    "@comunica/bus-dereference" "^5.3.0"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@jeswr/stream-to-string" "^2.0.0"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-dereference-rdf-parse@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-4.0.2.tgz#b1956a4e8d2ea96f6b134bff9e7c6c9b1a870a3a"
-  integrity sha512-hl+1Zj8dIXXePxBOhPhrmJqMSU3QyHlzEoEG6Uy3Wqowm345nXsy5NTf24eUldOArhhkvq/Xi2lDQh29stomCA==
+"@comunica/actor-dereference-rdf-parse@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-dereference-rdf-parse/-/actor-dereference-rdf-parse-5.3.0.tgz#a9d7949702abf0c6ad676695a00865ccf4e68525"
+  integrity sha512-FXplPboI5dXy7DEtDo+IvDSpZoJxR0lIffGJ5ZLHD5r0nMY3egmg+H1Via3Cv3NfUW1NkEOPVb+ay35sWDo+ng==
   dependencies:
-    "@comunica/bus-dereference" "^4.0.2"
-    "@comunica/bus-dereference-rdf" "^4.0.2"
-    "@comunica/bus-rdf-parse" "^4.0.2"
+    "@comunica/bus-dereference" "^5.3.0"
+    "@comunica/bus-dereference-rdf" "^5.3.0"
+    "@comunica/bus-rdf-parse" "^5.3.0"
 
-"@comunica/actor-expression-evaluator-factory-default@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-4.0.2.tgz#04ac6f650d848d31b887520a0bddcabd6a16598f"
-  integrity sha512-WLq4bdYDZrhoc7QqnUh8HXx8FgTHO2lsKZeQmhmO3mxX03D7+CeeLqQjJFWu06ZtvxQpjhjzwfsIQUvOKqr4cw==
+"@comunica/actor-expression-evaluator-factory-default@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-expression-evaluator-factory-default/-/actor-expression-evaluator-factory-default-5.3.0.tgz#0c809d1e5d35e3ed4efd1ed49a1755a799fb8fe6"
+  integrity sha512-DlPOGnaZzJQr3w1rMszrPLIGLJIPwQgtfyfLUcUhtYuMMTAzvfP4xpnA7RNW4CkvlJsynWf0QhDLECjMSw1+Cw==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.0.2"
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-expression-evaluator-factory" "^5.3.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.7"
 
-"@comunica/actor-function-factory-expression-bnode@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-4.0.2.tgz#fe121139ea757733da3ff84012ec65afb9d30580"
-  integrity sha512-905Prirlf/V7hhHo/4/1V4w0d6mjbCm1+j2MCi51sVATOyxQbMjPcjDGqHCkZm1lcg+u2+CFm0yyPExzc3fENw==
+"@comunica/actor-function-factory-expression-bnode@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-bnode/-/actor-function-factory-expression-bnode-5.3.0.tgz#79ff7204a31de173dcced57c63381d828283e2f7"
+  integrity sha512-ehEsR4UERdQGVq/uFyHpqV3egO9SkO/jGIESM8FngimoiMftPN71Qddgkz0AmS8r5mkNg9lADswR5mgQzUB0YA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-data-factory" "^4.0.1"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-data-factory" "^5.0.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-bound@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-4.0.2.tgz#23a9378af5e0a43740fde13401a2d7777db9d3e3"
-  integrity sha512-rFy8fEXwPHS8LHv9YQw06P0SDmjB9zq1qq+19TyJY67sz0oK+Fx9tjlOU9NlRNyIdlcTDj1Etqk4widEZpgphQ==
+"@comunica/actor-function-factory-expression-bound@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-bound/-/actor-function-factory-expression-bound-5.3.0.tgz#ee1a992b709c01c178a61aa1801e45708970e9f1"
+  integrity sha512-b0Dg6K7clkaDTHZzzG5OzhZI5IEF+kUahl+uFI2iDXULNhEUnnZpI9yrNeCMqSDUa3HUq/M0mvrWg0kskv70Jg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-coalesce@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-4.0.2.tgz#5ffd48dd75c4abb8f7658148ae691fb78f290ede"
-  integrity sha512-yIeyFHVIxz/hqmrFEjtoqVzJupEBehcnu0VQyAiGRZICKx9lnP6WMKvG7vdL1VJX37WpxrosVpALNhOXru41Ng==
+"@comunica/actor-function-factory-expression-coalesce@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-coalesce/-/actor-function-factory-expression-coalesce-5.3.0.tgz#2c10a323e876306760e2963ac80e7111489cd483"
+  integrity sha512-pDqtK2e9qD1claWiCJ0pSYGCcAJQVM/JzdQEaGjbMIGJosDdJfPJ5NiWS7GeU2/nOUJVlsUocpURy7Pw+6h6Iw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-concat@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-4.0.2.tgz#eda8d868ad243c3ed81858a0ede4ef278327f1e0"
-  integrity sha512-rV8t/mecA0/oS5Dwdz0RtinbiH03UWEADmhCHhiyqwvXCwJzWhmcQUhSg6MczAv0KfoLBasEU/kDGQ9o30NNSA==
+"@comunica/actor-function-factory-expression-concat@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-concat/-/actor-function-factory-expression-concat-5.3.0.tgz#82e463d88075daf8b5daf059a3d302c0ad6d595d"
+  integrity sha512-4fHbURg9zA40zf3ZNo3Jh7f01K+xZoE8EBZMlT+f9sRN7hrV/486Nfc5Dg+wsDBPkjgWk4nkoXqFQr2O9Vkjow==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-extensions@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-4.0.2.tgz#c621b315546a011e12c1126067adabcf1bf3c8f0"
-  integrity sha512-nlAVEnrzcB3Z7QsewB5p2aaXUUV+UrJuwdLlsTfNkWUHxN04Nxwrt/zajxhY6Ei+JdiI19YQKRzt5mCLRzJ6rg==
+"@comunica/actor-function-factory-expression-extensions@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-extensions/-/actor-function-factory-expression-extensions-5.3.0.tgz#a71d5f357a6b762fba27ac78afc9afe68f2c4c5a"
+  integrity sha512-eEB6A14IIetbZ3uCRtz2A3r2d4Lq/XtxNwT42oOBH1UxLu7fHBKL+8BobwSdp+pzzJVvzrv7keVy5lz4g84hnQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    rdf-data-factory "^1.1.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    rdf-data-factory "^2.0.0"
 
-"@comunica/actor-function-factory-expression-if@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-4.0.2.tgz#f0e37082bd5331bd42a77bcf07f45d6cd9c38c46"
-  integrity sha512-qwZLpH43r9lEoOUxx6E8jDCckoCFWk2j08JTVDzgLxWDPYGwEqxg+7MWo4FYthv4rIJcFW8RTqdQd6vICN0qOA==
+"@comunica/actor-function-factory-expression-if@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-if/-/actor-function-factory-expression-if-5.3.0.tgz#3bac673b6063f754107eace35dcc5d98c2e5f2e0"
+  integrity sha512-YxTBMXUaqUAj8qKQrhCWQrygM1j20oDj3uwzWNUqPXd6JgSiXyGrlifxYD7Y8Pg9/6FLsn3aCprK/TQJqJUZLg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-in@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-4.0.2.tgz#abafcbe340c5adf880ca28e15cd62e3f5a8139d3"
-  integrity sha512-AT1Qgqdn1+GWBQxnKF69gWhbFPxwPRBPocwsGisLvC9iXd/v1/gkIfy/gB01d0dFloKSc6jmcSnKmtknihXR/Q==
+"@comunica/actor-function-factory-expression-in@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-in/-/actor-function-factory-expression-in-5.3.0.tgz#e46a889ceb7b2c2c355663b737910daa42028fe1"
+  integrity sha512-SIgBJHHXwDZ0d8NAfWbnLHC76s9KV3SGeKbX7+oPvCvNsYh8aAfZqAHbIKddNQSqpTaKzeD5n46Eqh78uumyPA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-logical-and@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-4.0.2.tgz#1dda498dad8c02909bdb051a2cffc9bbb4037834"
-  integrity sha512-oUj69F/TaSPfuHvezrrfm90AC4gcc+eHHqst7BMl7uQM2MiiUzhpbYtHNP1Z1fqa6nNMNCnvmzU5vhX7gXSEvw==
+"@comunica/actor-function-factory-expression-logical-and@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-logical-and/-/actor-function-factory-expression-logical-and-5.3.0.tgz#c15d7314e51d8ab504de74373493c4cc85e8fb10"
+  integrity sha512-mqIbZjsmt/ABJkuZ6WBXFkZigfj+dPcHw8tNDRHX4cqKflBJNtxbSd4p0aHcZo4pZkhbpuQO8XlL5C4NBTFR/A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-logical-or@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-4.0.2.tgz#e92536887f7aa9b54179aeeacd43ced4cd1223f9"
-  integrity sha512-jS/dCknNzinSNzx1/2kwdjEMQM/6DQ38/wEE9Trqdn3Oh8clNBM8fp0miov8AKEykKI4E8VDGpkUmYojFMN/MQ==
+"@comunica/actor-function-factory-expression-logical-or@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-logical-or/-/actor-function-factory-expression-logical-or-5.3.0.tgz#7759d64406f7e5910c21713585d2bde21db441c2"
+  integrity sha512-gqYJvIPTU6OY6QZpsA6z/Xxs9WmTy3rY6mxfZG7F8BfqgHzzKeTexa4fvd5GppcWZuaCIuRhbBVa5Z1zleffxA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-not-in@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-4.0.2.tgz#083c8a9cea89b26f22511633dc7d3bbc64fe5d32"
-  integrity sha512-S7Lipa+HBNAi9NJHDkpXBx6MRcWPg26V30/WZ4O1PckZKSneZy4KhCoFe/K4KTao57HMACk0tJB7DwyU1eyjAg==
+"@comunica/actor-function-factory-expression-not-in@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-not-in/-/actor-function-factory-expression-not-in-5.3.0.tgz#4d3cd140101ec6f66ee326d5d585feccfd1b8875"
+  integrity sha512-1K5sR8h8PrYOH/grF6FQBKGI2Be/VwM/kjJ8Hef5oBAYvf1hvYkAaxQ8TOGkLW8navDhoCR2b0I19D7EZoP7zA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-expression-same-term@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-4.0.2.tgz#db64a268e77db4849941d810f8d09629968e2b89"
-  integrity sha512-ClfUGI21gMI5hBNzN3lD6BQWZh70eNH54AhAR+Hlr3pSFqUE5MvmrhooBb8vWkrBMkWNENghwucUTMK9u4kuIw==
+"@comunica/actor-function-factory-expression-same-term@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-expression-same-term/-/actor-function-factory-expression-same-term-5.3.0.tgz#83ebc11c0647ef390cca5d280f806526386d8a17"
+  integrity sha512-BrYg/2YkC1R9DTZEdT6sWCwvoRICvLT+62DsdF4p8XZxe2T3VEQyAoQTivwkbTpRQnxiLSh3gTd2I3AXwQOw+w==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-abs@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-4.0.2.tgz#716a19625ea37c97cafd6811ebb26d5dc0268c1d"
-  integrity sha512-AJM0JVPpZmq7Jc1I2dqhMTuYqX9+eGITPjItA89hvjdXOQ9k1P8KYIqjRyNoKfSzPz9q5pMlHc2Dw+1jkKtieg==
+"@comunica/actor-function-factory-term-abs@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-abs/-/actor-function-factory-term-abs-5.3.0.tgz#63dda24e6039b90ecd23cfa0219638d95c296f29"
+  integrity sha512-dTltBZjkgga9j4Q+BFqvEE+WvgEWKJtWjIxWs67KKikNIoIfZDCYWXMXlQMJNC4N09qNATEM7iyz6ttLfY3wHg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-addition@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-4.0.2.tgz#43a9835c600f627911fc4e99da07bd8dc78010d2"
-  integrity sha512-huYq+kw1wZToFsoWh8rwOKv5wAuHHul4mCPoZ2X/rj8I8sVrEfyfsiYOd6D8wsH9XFr2+1qomS61NAwySJomYQ==
+"@comunica/actor-function-factory-term-addition@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-addition/-/actor-function-factory-term-addition-5.3.0.tgz#9ae071fb7d80baa173d22c04699e5e6d9d031cf2"
+  integrity sha512-A5sEZKM+NJ2tiaFP6QN8oNY+0IF5JTVNuMrlpl8fsVmBzpUMmc+j7SzttQp9wmqo0JKmFdq/hSGhBbhmtqtpGQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    bignumber.js "^9.1.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    bignumber.js "^11.0.0"
 
-"@comunica/actor-function-factory-term-ceil@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-4.0.2.tgz#de7f6753b737a04387f2ce51289955f375a90baa"
-  integrity sha512-I2gSMJ1bo+dvyHSoW+fvmhjnzuhF3e8qZNZAyNai8qzo6YPKR3sM/FXvJYCIpXYRhI/PlrmFMW/HNK2lVScRPQ==
+"@comunica/actor-function-factory-term-ceil@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-ceil/-/actor-function-factory-term-ceil-5.3.0.tgz#aa02f07493a4cd47da1b318a2f17284b1d2e018f"
+  integrity sha512-ozUlZyJt7Ra34EDOmdxnrpnuH1fHGOBmvFUavD+0uR66PXPrsV6EFH/HW0VNfcVe/iPehN0lDFF+SyFeLml3Ug==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-contains@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-4.0.2.tgz#464de8162b19f927ffaf77eade549ede63b7e3df"
-  integrity sha512-G1tnvG0hlHrgaTAHb3ofG+nC3HDBlYskqcP0Hr2BX6dwcQEWrTuLxAxLwjbiWdy2dm8W/c2oJxoED6PLF42LDg==
+"@comunica/actor-function-factory-term-contains@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-contains/-/actor-function-factory-term-contains-5.3.0.tgz#d536351a6483a99270af83f8b05663318cf4e617"
+  integrity sha512-6dYnydAdwOfrcJRq9/R7sUqrmCXXZ5381KHtPgnw0va4K32D2QxArIlWO92dYZzDgJ1v+UNRXK5xmbOOg4qW+Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-datatype@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-4.0.2.tgz#19b26ed957c978a699d0217208b19932f4998d89"
-  integrity sha512-8PMWdL6LE0SkcAXQRg38YSMYUHxMByYMn4nqUv+xa1MBihPGozV1klD7HwOoAkCDab3lsk3x0lvb+SXfnAjxUA==
+"@comunica/actor-function-factory-term-datatype@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-datatype/-/actor-function-factory-term-datatype-5.3.0.tgz#ca292960efdefb2759639b6aa8eac4f256509a25"
+  integrity sha512-z7SJgfJvElB+dR6CdnMgMkB+qK2DupXti7yiqI4DPADiHovipriz0ChAplGSWXzJ+O++1L5PHeeYiBqY8rpuzQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-day@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-4.0.2.tgz#29d928f81303de893a856cb4670c44d631393b1a"
-  integrity sha512-BSnUdEl8rbCBQUWHVPt6alSvXbzb17cjFtEkldfveqB/pmsmSh3w0EI+MATLEfQgM9tz24WtCVASyDtmi+ZJsA==
+"@comunica/actor-function-factory-term-day@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-day/-/actor-function-factory-term-day-5.3.0.tgz#83c7aa2eb8027a3ed50e3987b78c6af98e92a134"
+  integrity sha512-jRYSd2lFENaqcRi0LGzr2JSG/I4zvzgBzlmvw4m8OXIZ75sDkCOPRguWPJoidq7AdmpK5mVNIEhrJJVNNDrotg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-division@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-4.0.2.tgz#2ff347efee485d4516222e054d30cda9277dc381"
-  integrity sha512-O69sUKBS8RuBGO1LXFomP2ZNblMOmByGg4YZq81IRhlFFyGshO5m5BvkYl5CZWHsLws9yz/vaUgMFa6bzJbXVA==
+"@comunica/actor-function-factory-term-division@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-division/-/actor-function-factory-term-division-5.3.0.tgz#a16dfe99d5d317690f335f9e201f952590e0c38b"
+  integrity sha512-vnVeRW2sAKa5KHY4AXlyYMF71DcAzr5zf7lCwPuUoXS+vKuAkO+tGztdEVjKxo4G0mzc3VVbmDuXO2MWIsOhrg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    bignumber.js "^9.1.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    bignumber.js "^11.0.0"
 
-"@comunica/actor-function-factory-term-encode-for-uri@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-4.0.2.tgz#7d28315eb4c25ed407462943800c0b6c15eac381"
-  integrity sha512-RFYqSRct0Y/LHwohmnupAdgmixv2oiI41a6RkgpcyBXzkFKdv+n/K8dCtZNoLJq5SSskI6meX2e9hwDRqtoy2w==
+"@comunica/actor-function-factory-term-encode-for-uri@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-encode-for-uri/-/actor-function-factory-term-encode-for-uri-5.3.0.tgz#7cc0d339ef348214d3c9898088ca8f9922c9970f"
+  integrity sha512-82nSJ9LhJqiCl9Aq0MDZa2ekUOeknMUJ6pHxnSYXeS9TYoA+xj5IiMw4tEsZIc7ziIuAQwcR10+mbHptYm3FPg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-equality@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-4.0.2.tgz#99265fc484e274612d114055e7ae4e60c580e4f2"
-  integrity sha512-lntQi/kT65c7fUQuHlhJloILA1Kh3un7D8TOisqo42TNySl0KBi1GE5WBVdU7nX0Pn8hydJjes8NCSS3VT/GjA==
+"@comunica/actor-function-factory-term-equality@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-equality/-/actor-function-factory-term-equality-5.3.0.tgz#e4ee63e012099207ce64e3afa7630ee312ec673b"
+  integrity sha512-wxXJVrrNhsljCmenegig6JP+2MJQtx3GdbL1BmGT22OL14DRYr4/GKeCcUTJkKo7LTGQijapqgU3zolKtOICVA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-floor@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-4.0.2.tgz#863bafbd04f19e81925ea2a567d6500fccd367d0"
-  integrity sha512-Gdc4iwOWZUPea7/z0rj3HLV/rwV3EG/LuoasQmmrn4EJwcxcVbdy1vHdD3tXdQ251+fVUWiJzKNQ75b5qn32BA==
+"@comunica/actor-function-factory-term-floor@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-floor/-/actor-function-factory-term-floor-5.3.0.tgz#07dbbd51e09788fae06e7113c3680fcc62df48f4"
+  integrity sha512-Yxq3DqjD2ezAfnB9r//q32zVqqSsA6+AKNd37PO4BByQiShCO3RIysJGCeh5f986OP8f6E7/QCS2EhtzGVteKQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-greater-than-equal@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-4.0.2.tgz#2b1a2c7dba9de0d7d9b1a3a698aec516257695ce"
-  integrity sha512-Yb1wtwD/PkeLTysaYh/OBT/Os6Oau+P6TXzeMmHhQoc4ozuanpRQtJxU9UgifsAa3emi9YmPzibQ3f54///dRg==
+"@comunica/actor-function-factory-term-greater-than-equal@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-greater-than-equal/-/actor-function-factory-term-greater-than-equal-5.3.0.tgz#349febfb4b6e4de67921b44ae9d3eb005374b219"
+  integrity sha512-QclM//r2ACVcJ4aUMD9aFf8DlPON/otvabvQDzqUs+f7ioOtd6j3aSOLSs96I64QCoo2BWRiAhWGLIQRRdhAjQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-greater-than@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-4.0.2.tgz#62b17125d78958c578812e95bb9bbb4f9c486079"
-  integrity sha512-bYCy9xIC0ep3EtYQ9H5ZYMe3fBN5hHhlRVj9RuafneLOzmiTypTobiVDBXqx6ks5dspn1Y4S0eD5+3YRWq9x2w==
+"@comunica/actor-function-factory-term-greater-than@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-greater-than/-/actor-function-factory-term-greater-than-5.3.0.tgz#d4739af29db906069a2851970330f98917d26eaf"
+  integrity sha512-Qn8hwSntpwenHGBvoVkBST0nRFz6zEnuhI+5w0Hq/eo2qKb8MDtrpEWn3KjG0g8F+UTHDygAsjTwnTijYdtlOw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-hours@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-4.0.2.tgz#d09616b9cd2185e6ae964240644e0b722132c3f1"
-  integrity sha512-oWVrEy0xDfeSMlsEy/SwBU54prQP/5GkfRjBvmrCdBXyAcrmdU+znhjF6OkSu6rgrIreae3KZCelVj8gGhQ8Cg==
+"@comunica/actor-function-factory-term-has-lang@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-has-lang/-/actor-function-factory-term-has-lang-5.3.0.tgz#89815b27f8d5db3d277e19db4393870b0f105f4a"
+  integrity sha512-wcFcYd/Qd4UQd30N1+L5tGQADBjVv90lk2y9NvxwrBl0LnfdOOSyaeVMI8IjAu3zs8U9S1rZEQygg/94rs+WIg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-inequality@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-4.0.2.tgz#cfe53cdd19cd705c1f61e1fb6a7da787fec6de9c"
-  integrity sha512-TNUTEJw9GFyQKcysvG5T2/2043wYL9OaTLSz+IJrbEQ3+RRxhLe1dT0EXVKYcqXUuNTIgtYS8gLjCje/+53fng==
+"@comunica/actor-function-factory-term-has-langdir@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-has-langdir/-/actor-function-factory-term-has-langdir-5.3.0.tgz#0b1f1d7d4f1bc9b961a67b6fec0470dce49cf359"
+  integrity sha512-WlTohELdTI6vzozhAd6Lxs+e/AByvWD/enlT3ZrgyP2blZ/QEjAMik49rRKfRZkLymC+I7SIZQoljsH03SSVQA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-iri@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-4.0.2.tgz#d15f3eef84397c0946863485d6d04def3e98e847"
-  integrity sha512-QklxGb8S6+4kjto6ZJvowgNtAqO4LtWH+KJR0yTZvwPmtioE1rPZV+6VeQutOuXGyM3uMs+gZrk6gUEPTdXn+Q==
+"@comunica/actor-function-factory-term-hours@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-hours/-/actor-function-factory-term-hours-5.3.0.tgz#d922f8fecdc1bfdf2ac01b5ff5f60fad2ac3c8da"
+  integrity sha512-84joaPb7/IOWxVeF5a2tdT4J2+bNCcT8OqLnw4rbqlnGVd0yXTe2eJIF4tb5jUvu06TYTkiF+TWf9fY48n5jsg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+
+"@comunica/actor-function-factory-term-inequality@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-inequality/-/actor-function-factory-term-inequality-5.3.0.tgz#7bedafeaaf1c425f495ce1e45d05ee1c0823c6c1"
+  integrity sha512-AunuPU6IfkjqimfjbS8KcxjgeE2cYseBZ1FHs+dDCHq7nHxl8lnoul/CKliQPWtqAkJPicXNIAX8Y2SjAy8Tvw==
+  dependencies:
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+
+"@comunica/actor-function-factory-term-iri@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-iri/-/actor-function-factory-term-iri-5.3.0.tgz#152460c1f02b96d5b9949388f8fe707e6d64cd84"
+  integrity sha512-qxdaqoAJmCNJ/u/XaU2hMxjo2mQ8vw5ZvBSNuMCbI+KXIKRLV9AidRvjKMnaSa2KE3maoxqA6r9+pJUHz+H3nw==
+  dependencies:
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-function-factory-term-is-blank@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-4.0.2.tgz#df7416a7d1b8d7fc99161ffbaedce61da6c9b9a8"
-  integrity sha512-ssoQ5e6Xfy1Ir+XiMl0fGxmSiIbr3Nq8riU5GTdqauP5/jIzPrs9d8Xq+nQ6wDmtrmqC1YrYTSlIu7lKZNzOLw==
+"@comunica/actor-function-factory-term-is-blank@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-blank/-/actor-function-factory-term-is-blank-5.3.0.tgz#feb61120dfaf9dbaa92cdfc4189a457e7499b393"
+  integrity sha512-q01xpJ9ms8+3Prz/UkMYOFJWQXZDSXYSY0EHgeAhSCpUMbpRNZFqwwJM5tJXMHbjB5AT4RiqEHGZ3mcW2jB+cg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-is-iri@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-4.0.2.tgz#c649273efe995fed8cc6932e9443378c0b92d35e"
-  integrity sha512-yiQz4C1EIoqMVsvSXs/56DIUTjFNyZg7qeG6lysv7Z1IEOh7+CzVgQptivq7dcx6zmG4A+qB/fL030GCQVMcTw==
+"@comunica/actor-function-factory-term-is-iri@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-iri/-/actor-function-factory-term-is-iri-5.3.0.tgz#7fea6b74ba3a7318ac4a79989f00fd9f78c029ad"
+  integrity sha512-5+kxYCn/FmPHFzLIqNosGftphXAuvUuY/xgpPYvUnTlh/gjM2BbCgQR6xiUmibnZPguJsCb3t7Nmygw45y2GMg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-is-literal@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-4.0.2.tgz#837f550064527bb7e6e1a2d1fa72f6c678a981c6"
-  integrity sha512-1Kokm3AaRyaAg84Mtf9CsOVk8AkJWLlYqadY5CV7iCZ756vR7Pw9W1YiOr8liDe0vg5PBracQt+S3kjRQMoSZw==
+"@comunica/actor-function-factory-term-is-literal@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-literal/-/actor-function-factory-term-is-literal-5.3.0.tgz#85dcc4bbf87649ca097c48081aac3941b30803df"
+  integrity sha512-oqN1BeRjNlHpvSi0aFHPQH/2/heTFo0S4OFolQD6i5OADTPbQDMmlgkfLCv6Vd3vJDK0S+YD571xx/ull0gqRg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-is-numeric@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-4.0.2.tgz#7b5306dac528dee47af852ad01a1fd8876c4b79b"
-  integrity sha512-MLTc7OwdXoINIxPUedl655l6ZiSj0mxqLr/x12YKTt5FQSXxczHGuwH8klgG9eb2ebr9M9VsjUsVxv1ZOb3dXA==
+"@comunica/actor-function-factory-term-is-numeric@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-numeric/-/actor-function-factory-term-is-numeric-5.3.0.tgz#b0f3041253728a982030b8a74065ff51eec33012"
+  integrity sha512-mxLI9HiODJVxG7X58rCbSnOTTF0eT/6Ui5G2m0/UQJJPM/kEusNSBnbQcRbUM+npeJKpNCZkDDwMJyhFYDLwRw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-is-triple@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-4.0.2.tgz#5903466c5d43350646c06de2551920e13861c6cf"
-  integrity sha512-jQE/EAgXLoQ9Tublsn3B3ee9XAJE10XrBwqHBNaiJF29r2WX+uAW6Sij71/C5Vg+PXbGnFs7SqEekD2Xj2K41A==
+"@comunica/actor-function-factory-term-is-triple@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-is-triple/-/actor-function-factory-term-is-triple-5.3.0.tgz#dd0fe969b527d5deff6307bf783654aceff23edc"
+  integrity sha512-IgToUw/6+FnbuCiR6JN99Phxbc8wdazIzGZtQVwA1XfSp00Prj1/i4ItuZKeqBZpntZbvyXHEafRSfa4SXzivQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-lang@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-4.0.2.tgz#cd1946e9df8ef4c1aba34021931a3ea939605be0"
-  integrity sha512-M0agN+JPXFeTiUkDPvNGjM6OF8hLputQPesDel84bx14XpJUurKFSQY1teWbx/v288IAD+m8R/QhIvcbuAnrVg==
+"@comunica/actor-function-factory-term-lang@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lang/-/actor-function-factory-term-lang-5.3.0.tgz#159b25765a6a5b5375aebc86efe85b7559953df8"
+  integrity sha512-L8kb+o8HPDy6VjQHpAjRBnn1C4BcTTJjJ0LhvNxJqPD5nVg5dD9BIWf2l6Vv3UMZX9CaUoDpRr0v5b1fULDJvg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-langmatches@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-4.0.2.tgz#825e9a4102a6815f19bd48f2ca8f276813b713dd"
-  integrity sha512-HTrkk/O3BA4o3bxw31F5kNDchG9dIk4IIrqG43dO6rdyhHnjg7KswqgANzrZ6JLweGcwrhLtz+Xb0kMOUeF7dg==
+"@comunica/actor-function-factory-term-langdir@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-langdir/-/actor-function-factory-term-langdir-5.3.0.tgz#d9f157154eef0050fb6c9dbceb2e8087b4b7800f"
+  integrity sha512-PPVlAVaVr2y+s9jz7LDC/6+P5GxeS2Q/NtAOc6+ISpTGvaN7dIinXK+3ECR1Ly0fGW9MgHWPkfPBCMnZjbMZIA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-lcase@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-4.0.2.tgz#ec0b7b45835acae7a606dd2b3ce4f52f2e95b4f4"
-  integrity sha512-lGTwn1afYmX2YmUAExk57euQX8xD3Wy4riLSclQ4JtAmB1ZdSL+qr7YBvA6nHD4c2LU+r53Tuo4Pdoztg/bSyQ==
+"@comunica/actor-function-factory-term-langmatches@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-langmatches/-/actor-function-factory-term-langmatches-5.3.0.tgz#28d12c1f29994b6dcfc1cd42c86b075a83e491f3"
+  integrity sha512-wSBLX2oP4Uj9Xz1uC0daTvrPePZ8cnEOr3B+MFENitQZOMfMQrxj56kqTDKlIP3ymWcnRSQo33mMUhjcMDNa7A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-lesser-than-equal@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-4.0.2.tgz#46de41c1065c805318a7d61afe036818a1180940"
-  integrity sha512-z7ENI9fcMMXJytvRPE/uKzwSDw57NRaY3MvcO2BDD9S+/5ZCHmFEMY2qS0xr+5khByoSqSPErWMbGMgI3dOGLg==
+"@comunica/actor-function-factory-term-lcase@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lcase/-/actor-function-factory-term-lcase-5.3.0.tgz#889d055c76c048bb472edca99980b1cb5c5cf096"
+  integrity sha512-Cz1hwmBSQKp4jkk/pPZl2Hz+bWzcYX5sgPFrR+5VOT/1GoXXRhKGxCGrlNoIvwTVmg2TsdxEUHBFztyQwAqXJQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-lesser-than@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-4.0.2.tgz#afccb421fc07d87b49d95ac3e8ffbc1fb680cd83"
-  integrity sha512-HkU5+2fyIOuOciTqTAxju7F+XN3+DBsqjKAH5VR4trn/LbZfes11hQlEb4+PEKrQ9G/t6VkViTx+b5hIKQubBA==
+"@comunica/actor-function-factory-term-lesser-than-equal@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lesser-than-equal/-/actor-function-factory-term-lesser-than-equal-5.3.0.tgz#d6906277064b8b11307fd9e0ec6b7501d0a6a65a"
+  integrity sha512-dZuNLI+cQGeSjq/DOzUQFvVMV7BjuiHzKiC2onOrjwy6ea7ewFBqepY5KMVjHbU+kjO+JChIglIVd9qmdet45g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-md5@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-4.0.2.tgz#c6c22550df48e1144041b6cdc0dddc8c0c244cae"
-  integrity sha512-gO5zwDWmku2J8Se/PXW/yf/73xF1wK4lLKd84ZP8kelihTfxXdm78ZJtUvCXdqtgLx6TOV5RzJbfJg5Zs9nB+g==
+"@comunica/actor-function-factory-term-lesser-than@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-lesser-than/-/actor-function-factory-term-lesser-than-5.3.0.tgz#43e8acfea0dd45f81dc9a0109418e9e9804dac66"
+  integrity sha512-93LdymVrC+9T5Wep6kiSbhL6Cu3orH4r/24FUFDlZcW+dSoPXQXeSPo315iTqpIALl0LOkXmrWONlq7YuqXRWw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+
+"@comunica/actor-function-factory-term-md5@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-md5/-/actor-function-factory-term-md5-5.3.0.tgz#f1f3b4b9fb5a297c3c09741ac57830bb5272abd9"
+  integrity sha512-ycyd5sjyfyxUyzg9xG62SSnm+xGXeCqmV57K7c6ecUezd5OrKZpW8PvobNQ8kYsF7NFMuJm6wxDBSxKkrGwpFQ==
+  dependencies:
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@types/spark-md5" "^3.0.1"
     spark-md5 "^3.0.1"
 
-"@comunica/actor-function-factory-term-minutes@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-4.0.2.tgz#d43431248ff9cce18b9ade4b5778566ccc7a5d56"
-  integrity sha512-INZLITPI2eWZkRzjFTt7pSGUfg/stXr3jG3pmiIksrbMnat9XDkKoP1zWZn3KLXe1QqIHvSWcrBQ1AtppAbcbQ==
+"@comunica/actor-function-factory-term-minutes@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-minutes/-/actor-function-factory-term-minutes-5.3.0.tgz#1afbb63ebb171f6d1bd523f1336bf6ee83c79a33"
+  integrity sha512-sALHIQ/mhXrSJMpPE9IJDEZK4bCH5V9v8e/ofTjn06hqIRo3g/oNbDLKa9MEhqlL6LiHUVV14yLBuDuTYmEucQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-month@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-4.0.2.tgz#306c70316bfdfcf7a3213f2c72bdeb2eb8f28c4d"
-  integrity sha512-FtlAiNzZdkJmZlittwV8Vv0uznoqtiNmr16MqGFd3CnB52dwrxq+2L4VRQk4D9zS3ZZq01Xf0iZ6H80mOq+L2g==
+"@comunica/actor-function-factory-term-month@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-month/-/actor-function-factory-term-month-5.3.0.tgz#1187c2aaaf812a3f6f39ff638643a487af54584a"
+  integrity sha512-T4FUk5Nw7TMim5Ic0j69vz3uoXYPUBxLFyUgtAT33EbFPeKea/vphGhimP/BcV/344Pdhh1uUJuMPDsHC1mO4Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-multiplication@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-4.0.2.tgz#455279dce42bfd08071b4e5c45a3996a38b8568d"
-  integrity sha512-IRKnSte3fGHnKUDmrRfi6blf7aw45fJ/ACgMJLJFOfgIvqwE4z5BKvKMBkGsCjkn/6r3b05vys46JXuiuOZXvg==
+"@comunica/actor-function-factory-term-multiplication@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-multiplication/-/actor-function-factory-term-multiplication-5.3.0.tgz#1242192637672972a0e3cecee54667b7e65b52c0"
+  integrity sha512-qidJiLwSt5+H9S/IQV/KoqW9bVhcw0qXY9pUqjWxrTDvOVwShHRzVBCXFbn0ru4DO4jt56CSMPRWZGdynPed8A==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    bignumber.js "^9.1.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    bignumber.js "^11.0.0"
 
-"@comunica/actor-function-factory-term-not@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-4.0.2.tgz#4763de32b0e34cc1742c0ca6eefe1bdc1522f43e"
-  integrity sha512-u6tdu+D3RXuTNt6EZavn3W9JmV1oqvsqjmowyzXLIdFiueCKqpsXMJqmrxDYtstx5lX73EeG5gxTl/k+yp0uAQ==
+"@comunica/actor-function-factory-term-not@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-not/-/actor-function-factory-term-not-5.3.0.tgz#dea9b0ded3efd71bea984596d7ee6a2cd8249d88"
+  integrity sha512-/jpBfyCknSEKAhRYAxcxvGv5/uRr/A/A36sAGpwknqWkRDGV2sZ7XQdn9bqP1pQwz4vxLIUhMTalPspNsAl/cQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-now@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-4.0.2.tgz#d1d7cc6c05dd60d3704d201c8cf60c01a2abd881"
-  integrity sha512-+LCBCaTHHtHV+nEP0a69t+GCTgvfPvt4b/l+xPLkur8bUzO0FjhLV41L+w2Z7P2zzPXsJgSkZRdaK+dR9J/ZWg==
+"@comunica/actor-function-factory-term-now@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-now/-/actor-function-factory-term-now-5.3.0.tgz#b6801a061f9162ccb4a5fd1d8e6ce3bb5d1f733c"
+  integrity sha512-18ZS0ysFKJwjGMBB9/xI5140DqW5sp45unDfURlNKLuRgQAqjK5kkjyr72otLNW1JwtlDDt5qun6kr9d84SFAg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-object@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-4.0.2.tgz#aa67e2dba06c28d49e72d374189b4ea98b5d5e8a"
-  integrity sha512-L2FeUX+f7BkllLQvD/n69MxSN5tCEw4Wg4SpOqogejo/4yl8YI0twuPP2XSowM+1t0vKvMb8fOftmgHEwBmKag==
+"@comunica/actor-function-factory-term-object@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-object/-/actor-function-factory-term-object-5.3.0.tgz#d6d590adaee10664e59437678f321db6f6878307"
+  integrity sha512-pgPS3sLt6lCZmQSuojuPArA5pOfXRjYwOQuqnl98/gkjdHgZaZhV+rLF2qYQYO0q5QxOUacp6l9yE7wfcoX25Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-predicate@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-4.0.2.tgz#a4404d1bfb051b91b2a971070a6df1bba3bb73d9"
-  integrity sha512-MWS3FzEmijA4vWbndFU7svlMEyZ874K9gbmK1bsG4fwQQQUlqeSULsnI3Izs3TmuMBdZuVJL9kq4DuQgNJI4vw==
+"@comunica/actor-function-factory-term-predicate@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-predicate/-/actor-function-factory-term-predicate-5.3.0.tgz#315e66e47e62c14d5a3d8058051991f81c9deee1"
+  integrity sha512-zR+6OPTQGpl+XDs41+leFhBZuPTvLUIspKscLS8ujLuMsT9eZVf7PZm4Rkhg3cL0BW5S60SqCdkJVEFAi7TGVw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-rand@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-4.0.2.tgz#f65ecbf61fa71f822f16731acdee34119984cc2a"
-  integrity sha512-62l7gKQpMXE0RI9czog7z4vE2t3ivb970KMpFfw1v/jtoHK26YBwAZLSnTJI4YOh92O7BoPaMUW8BdIZ23ukGA==
+"@comunica/actor-function-factory-term-rand@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-rand/-/actor-function-factory-term-rand-5.3.0.tgz#902e5a8a82edd1f049fe03f294ea684ad4145720"
+  integrity sha512-ln1CvevDInjP7w0sGdoYqKesW2FuQ/eM3VgPFbWC4l3kUP2xmiHGSO010eP6He4WDtsZsKBk+KfPsMMUGKXc2g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-regex@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-4.0.2.tgz#c090575e00bab42405a52abcff95f99aaff94dc6"
-  integrity sha512-kAUdkJpJxce6/w/PRf3AVnW+ymQNUhBvDhNmeQq5XWNaumRqku4czyg2xR17sBoAXa85CE30m+JWgvA4Xvu8kA==
+"@comunica/actor-function-factory-term-regex@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-regex/-/actor-function-factory-term-regex-5.3.0.tgz#706740fb8a337deacddcb9f28dbb63cfb45190c1"
+  integrity sha512-zFHFkF3td+UqcM5vwLXTzRRkSSiyDPFqv9QPZADp5kiDYG9bh/dVYvEOgMGV5k3tbBAJOmm9QXcgLHLzEkmsQw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-replace@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-4.0.2.tgz#02ede1f1dadc117cec7f4b65ef3dc383c7e2caa2"
-  integrity sha512-rO13hOSfHIszrcEXqy3ZGCzz5ybnb4CGyBLrV5qMrV8L4wBkUO8UbSAmUHmar0ZURJr67ths4K7GXbdmBOQDiQ==
+"@comunica/actor-function-factory-term-replace@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-replace/-/actor-function-factory-term-replace-5.3.0.tgz#8bf5d1886983bf570ad209eab54f9892ddc2f933"
+  integrity sha512-Pp15O8ebd88uV0s3CFQrd7SlVJ9XCD+Wd/ql3CB71Ak1tN1jY0XqrDRZsxqjGgG1dzotXExbAaSR5pe3G+BdGA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/actor-function-factory-term-regex" "^5.3.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-round@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-4.0.2.tgz#5b054373d74766da9346427a1b4f2e8836208445"
-  integrity sha512-h5MOh8cXilM/KZZZ6XtCt15A3UM5LXqJ3m7HPmGFfMw77pf2rILSYuktZTCwrI6jzx/2Xk2clzTHCVGrPbj9mg==
+"@comunica/actor-function-factory-term-round@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-round/-/actor-function-factory-term-round-5.3.0.tgz#0c06bd274a68aab6d39c4aab13c5c14612136538"
+  integrity sha512-YSvkEeGorh5gb6QGL00TPrAxlTz8JOxLN0LTzo1ToQ/2WkMAWv/nhwNUaxuxPv+HuCMg7HWLd4SecQqSUWXhdg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-seconds@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-4.0.2.tgz#2a0356a46c0c1f9d23ee9434c5323c2c5fa31caa"
-  integrity sha512-VLYiAV9rUPDFXAT6c/SO+PeiT5Lop2LZ2wxSalNdeG8Jn1eiIOtzkifnTBJy/gRyC5pirC+/oCUG5I7OH09EZQ==
+"@comunica/actor-function-factory-term-seconds@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-seconds/-/actor-function-factory-term-seconds-5.3.0.tgz#cf6f7a211d9b25e738963b52f971776ed5abff6c"
+  integrity sha512-u0p4kRtIcCxL944AGEJzGbYk7JwurFGu4NrwnS8egBXeGISRjufoAU9ZECP7vIJza+TZv2ir5m3FP9RyWqpBUg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-sha1@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-4.0.2.tgz#70dada89b47a013559fffa2d4815148ab752229b"
-  integrity sha512-HCyZWyFznLCHUyQEaTRcsaaNtEedoJsLaWaj81PLUD25pQnj3o9XvyAEx5fO1h5IuFh+WRHcSjfrmBCw8TMd8g==
+"@comunica/actor-function-factory-term-sha1@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha1/-/actor-function-factory-term-sha1-5.3.0.tgz#03556c7f2f183c1fe4eb684ea8a020ad8d432ce2"
+  integrity sha512-GnsH0U+PfxhlCI3mVm5547t12IS94u4jk3aC4ZP6Oxw4WWoOFJoYg5e/aJrgwWw9F0e582YWV7C+oAcOa6QMeQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-sha256@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-4.0.2.tgz#af2d9acaf99c1c924a122c0ac52876102a0f7930"
-  integrity sha512-RmxIfcfnEUQcQwiWN5D34WqTNjttq/+VGINdwZ3JRjP2lhAbtXxImYRmatV+lTMBJVChNGs1cRZw6XaARMml4Q==
+"@comunica/actor-function-factory-term-sha256@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha256/-/actor-function-factory-term-sha256-5.3.0.tgz#5fafe2b17286a37b04233836bc7b7d68c0193640"
+  integrity sha512-l4NxLQZ2pX8/8KunB8tS2GDCoR/H8L2e0TRuDnF4J9o0MkV5DyNhnGdpBb/46l8v97pSOceLXD6XeYUEYE3Rxw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-sha384@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-4.0.2.tgz#8dbf1ef21c6fdfd5190fc1dba89bb00d2c25eb8a"
-  integrity sha512-hvQNyn6ZgodYF0gkj6LiRdL9A9A7Hsnh/HbtG5R9ojJ+zkigembX8EoR0fl8PxrorzfAeB7kRRRGIUUkSEIqCw==
+"@comunica/actor-function-factory-term-sha384@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha384/-/actor-function-factory-term-sha384-5.3.0.tgz#9bcd6d26ad327b8af66f7b2d8e2cd4b6d04fc8f5"
+  integrity sha512-Bis+CineidELoPZHHy9dw+YRrBhpVuMjH4LTouHy/KxqOefvcWFt7BBzrZX53HRWr8BNG1WWLhlOc9muGrGbNQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-sha512@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-4.0.2.tgz#57d1c9e2510e02b95a3914b03cb2fe6aa4483a86"
-  integrity sha512-93Hg9yUfuz7biw8gkYw/zL8hEgvqp78VYM0dzEI9R5mlOUaGMhLxpEEL15b3G/w2rGLonZ2B/+6v/VIhz6Mzaw==
+"@comunica/actor-function-factory-term-sha512@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sha512/-/actor-function-factory-term-sha512-5.3.0.tgz#67652c83fa649d35c0aa61b77cabfad016e1d366"
+  integrity sha512-1Cuto34d1DNNP5C8EEzTsREAw3PKvjCJGxhBRaBr7WEoffMjpFQT1EJvSBSPezWYpLjdjj6sfyxowFOUV0bfkg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     hash.js "^1.1.7"
 
-"@comunica/actor-function-factory-term-str-after@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-4.0.2.tgz#43032fcb82e17c6c26c8424000f9d47cf66d16e3"
-  integrity sha512-hQqxUUvI8PhTObGUtijk4gk9GrTQuZrZZbDC2RzdVR/3Y8FmZh4jXA9Q3WzF2kktuvQV+z6RKb+mQ2VMtUqWEw==
+"@comunica/actor-function-factory-term-str-after@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-after/-/actor-function-factory-term-str-after-5.3.0.tgz#282e54d7677f38908fc1f70ddb9b205f434ac53e"
+  integrity sha512-LiKZu97xsuHLTMkpADsxbFn2QZcdN5xLXmg5TCGdA4jYwhTD7IWecxrlT7UbpoXLPvgiD7aeBxNrEXwXOUQrog==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-before@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-4.0.2.tgz#7d056ad8e6fbf679a6f0d3b6cb0b061fa48279e5"
-  integrity sha512-ZCm5FzbzWgpww5ALTGly607+TIxD85u51cI3c9DRmnd+nBqlIStJ1/aVHxkebAUEVNpRcFp1QVYcEp4K+1DdFQ==
+"@comunica/actor-function-factory-term-str-before@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-before/-/actor-function-factory-term-str-before-5.3.0.tgz#232d30e9eba236c4631f99c9c7e0da8e6313650c"
+  integrity sha512-P090fcLfnVwyC6iDJMGJ0av+jmUurV7SDsVPW7O1qUNW4cXiMZaj0lbP23XEa0x/5PPX26f8Nitveawv/ZzZUQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-dt@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-4.0.2.tgz#572badc15dd0f449868a45368d541bd673567179"
-  integrity sha512-4kSiSOb+OyjfQQ/8/62cETrkDAV1O21QsoUhqY8Fc0fepCcK8g/AH1T0EzFMaS+Pl7ZwTTkyL7LFl6jIVS6N7w==
+"@comunica/actor-function-factory-term-str-dt@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-dt/-/actor-function-factory-term-str-dt-5.3.0.tgz#5b6edaa3813ffaef54ab359755c118c210e1b694"
+  integrity sha512-FTuepSrOU6SxJW1Y5MxdU5FJN9/2wIE58DcpvmVlipVMhjTpsWfw/MRPg3GYCampS4M+OMpKxFzbDVRGdXjtfQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-ends@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-4.0.2.tgz#eacfea53fb006819743ac1fbcbfe46c4432b2ca8"
-  integrity sha512-qvS4JQGZr6N0Pq7NTqFms0yb0JosWJRfNlcb8w3A5EjRk8n1HpJmzS0jRu9lOEGQ5WCdH4V0pkW04oduRYLimg==
+"@comunica/actor-function-factory-term-str-ends@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-ends/-/actor-function-factory-term-str-ends-5.3.0.tgz#1f79220d2e164fcb8dc1ae9678358b2baf60d936"
+  integrity sha512-oNPkw0ReAVGsXiZl5yMwwMgMOcv61Bs/prrFE5iIas9HjwmvQjlcJHT4S7WEH1s1I2fLFF8dl0nOJHNoO8cUDg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-lang@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-4.0.2.tgz#7c0c7539d9ee8c4c64cddb5aeef53ebe6cc6355a"
-  integrity sha512-4m8H87e1Tcu2HJ0Rza3/59ZR0an+Aq63kASBsplt+Y00YbM5hw93mr6tUccUMXIBeqvrHABk/5ZlbLqS68LoOw==
+"@comunica/actor-function-factory-term-str-lang@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-lang/-/actor-function-factory-term-str-lang-5.3.0.tgz#8955cd7f323d78347962934c9531e6836a715223"
+  integrity sha512-a5+7ccZYB3wrpC58UD1U4SM2jczZYpeGha8do7WMe9iapxat7XO95E6v44P3qcZOHlHv5HIOYgktVkLkt6oL2Q==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-len@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-4.0.2.tgz#dce531cf58bde8a3a6dc0aceb83e07b236e17f22"
-  integrity sha512-s4ped8K3IO8BC66UNDOWNvXgtWcW+HT24PIK9IZd2T1a8TqNAi3pNBS6uTLlK8BwxSbWrovc2/TBq6X15khUSQ==
+"@comunica/actor-function-factory-term-str-langdir@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-langdir/-/actor-function-factory-term-str-langdir-5.3.0.tgz#bf28ba0a7d812af3053a814f104423257b2e8fe3"
+  integrity sha512-6MoEM6ZzSussLJC2gi4+HqIg6dxpGJk2qTrBehp9vncmTsOlmGrIoruh9uStZ1Si0nrTeyvowtB853jQrKZGGw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-starts@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-4.0.2.tgz#b3373c2176d513f1f863682eed677aac5b4a44ab"
-  integrity sha512-odSBsRXx5g+bcDUj7b8HcqCnx44erEFs0NQgEkBdNrZY9gm8BYxREuM8CFpmQqfmjk4JiFybqU+z6Hh36I2I6A==
+"@comunica/actor-function-factory-term-str-len@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-len/-/actor-function-factory-term-str-len-5.3.0.tgz#bf9214f2c4cf57c98d03a3df085fd26c4683e6eb"
+  integrity sha512-NYeG5TZrPqfUfVwb2Rf35QGF7e48r7yluDpqPWsLaPloGdifwtTJvx+r4P4drkxgRNGhej88RafayqeQF1Y/GQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str-uuid@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-4.0.2.tgz#8e55e41e1d37ac7f358aedb1e40e9fa506dbd20b"
-  integrity sha512-g7pYwLFSwJG4F15VBCmAxs92vSVH4AeaObhUdPssGDYmqssvzus4ILFKbycXDkSAAmBH7m5bAmsapDvEoRSkTg==
+"@comunica/actor-function-factory-term-str-starts@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-starts/-/actor-function-factory-term-str-starts-5.3.0.tgz#35c443dc49b70e2babf8f49be1141384a21e6992"
+  integrity sha512-HX120EomFPcDiGTzI/J5EsCEe2c+il3XEs3gSsqmFDP8bX6djHxK/N6so1lZzzTf15QAxJuSh86z5zojEeCq7g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@types/uuid" "^9.0.0"
-    uuid "^9.0.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-str@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-4.0.2.tgz#823b0546bdd4a96b6dc4c8922a2a1396af4b8acb"
-  integrity sha512-v/9us7ZK+VxO37Xf+w5PLeEZtuQZL5rHND6EA9VIIU2tJrLlF58G/X0/0UflfOAfPOT1pGPJxi8iI6yEBJ0Cgg==
+"@comunica/actor-function-factory-term-str-uuid@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str-uuid/-/actor-function-factory-term-str-uuid-5.3.0.tgz#86276a05f302c35369d2246be036dd09d37de48d"
+  integrity sha512-mQTLBTC0V5Eq9uIA7+MZSU34aiWA1nowMcVkk2EfX+1TbnApDH4wNEakTbonUFuTRkKG3SuYcoQFdlljMgMQRw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    "@types/uuid" "^10.0.0"
+    uuid "^11.0.0"
 
-"@comunica/actor-function-factory-term-sub-str@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-4.0.2.tgz#cd085622b70e0326b94b484351ab3a4a3bb976eb"
-  integrity sha512-j04Ev9j581HaU/kGkiwM9TrRvPT9/XLJYy63OVKH6e/CFar3W92D4YnW/LnCFhGpKLW8VxVTIU2yuddOEHCbGg==
+"@comunica/actor-function-factory-term-str@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-str/-/actor-function-factory-term-str-5.3.0.tgz#df88b66537c4715f0d6a117f7db47aee113de64c"
+  integrity sha512-nrSGuAwFeF+5NXHsAIvoUgXbGZ46nUCCcqA1b8aKF+/074qb652ljb6P/nXv5ShLgsre+fQ0OFGe+z+wI9A9bQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-subject@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-4.0.2.tgz#e71187e384df2431b4e36796c66fd5680d0448fd"
-  integrity sha512-EtW3oxF0P7B6xDb8Bb+oYlA96Bj2VGhn+WVGHGPY3RZU03T/tCujx+0ZD/6rzk9xDQJbrQpt2wYu3Ry7ZAI0hw==
+"@comunica/actor-function-factory-term-sub-str@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-sub-str/-/actor-function-factory-term-sub-str-5.3.0.tgz#1b9cddaa4c12ec769ddcef84572a45c9e4ec3976"
+  integrity sha512-eWwIKdz6878shFiiguRjkMzVu5X8r0+KnzkG9ulnmARDz3ISkXKIpQoQsIj8sZmUtxpl4wS9sEgVjvj5umlagA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-subtraction@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-4.0.2.tgz#2ee6cab0bb6e1b1cc3a1e6b333e2f3e883625146"
-  integrity sha512-NwVd1OvP2BsrypLD4Kg8MPlJ4BdHbGOIQ+KaLh+T6tvV4cRB1NbpJqHMgMtjYp7aCgIRFObThKHyrse8elvI0g==
+"@comunica/actor-function-factory-term-subject@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-subject/-/actor-function-factory-term-subject-5.3.0.tgz#4634536410a1b01958a679ff8ff4f5cd18965114"
+  integrity sha512-pj0RCMF9oaYdXgxwh13c4c5x4YthuFfMnOMhat9FtmbN991gutTqdBHP4dxsML1iRyYfpk/WOl+DnEY6CSBxCA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    bignumber.js "^9.1.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-timezone@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-4.0.2.tgz#62fb3803e870549bd703056a20c1a45e3e20d590"
-  integrity sha512-LCzzIvL1BhPfffQEj1RIrwlkzmwWEDm6o2avqGko0Jyq8V/JdkBZEaD/NVpwIhVVIG5g8sjH1kxvQW7ejnxiRw==
+"@comunica/actor-function-factory-term-subtraction@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-subtraction/-/actor-function-factory-term-subtraction-5.3.0.tgz#e5ee67ec1ea4efb09cd1a143f217930bc608d43b"
+  integrity sha512-j5uzCNw5EqJ9GjthhBlo4IpX8MSJvCbU3DbVGB1N/NZkGg5LMeHC3/CKfYurusgWCNbD7c7RXr65pAohj5X5ow==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    bignumber.js "^11.0.0"
 
-"@comunica/actor-function-factory-term-triple@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-4.0.2.tgz#89a241e8ba323efd18898290e73738aea7ce8c28"
-  integrity sha512-/sCpzcauNlZz7C7qcBJnapGUfY4L8MbXsMDBzxXREqT4QC2PwyM07brxo5lhS7zI/VH5vIVU3nORMoENAJh6Gw==
+"@comunica/actor-function-factory-term-timezone@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-timezone/-/actor-function-factory-term-timezone-5.3.0.tgz#bfada213a954bc54626d28791081ce95f4f26bcf"
+  integrity sha512-TtQNwQFzBuot0YtgnIr6uGjazblmJpvUYaIJmHxCZEhDxmLyidNS7pWvw45n3w/puwYArjzwn+tS4zSCZlwYVQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-tz@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-4.0.2.tgz#606f10f2a789614bacde086bab3f35366828a738"
-  integrity sha512-pLD/5OL7nJjaySPLhwJsFU11vYB+ZMPlidw6Ziiff8UhAzZXMOluUWgacEZvJbpRlcDhL7qieLfa5TknKamP4g==
+"@comunica/actor-function-factory-term-triple@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-triple/-/actor-function-factory-term-triple-5.3.0.tgz#43582019bfab1f875125140f4819fd2f96de5e62"
+  integrity sha512-Cj4kSimz2e7/SRswnn8RuK2ccNWWT00Wwvz0stYBEGll6X+G/jGiOEnd8yx57G9GoeTh2/ggE8vG5wK+rBF+kg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-ucase@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-4.0.2.tgz#43a7eed6df87008c3d120812cbbd825fa17fb979"
-  integrity sha512-xzwCIz6PcNeYXxfGYoxddsLE+qRTfIDV1iSj3rdUL0JqPf5+HuHIT6B7RgluPQH83dyM1r1rtLTyV/CDh2CPSg==
+"@comunica/actor-function-factory-term-tz@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-tz/-/actor-function-factory-term-tz-5.3.0.tgz#10a685036dccbeabe1ce0933e3b969c82e7c3672"
+  integrity sha512-OpGcbjrp5/L+efY/IouVX6x4UM2FbNtyUQhPon2UJPvg/JPzJlBKZCq2NwmjmAmXVyU2t1WPaaO7ZbuWHWaNBA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-unary-minus@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-4.0.2.tgz#272d1362f856d8d4621495e9532a8ab2c8573e12"
-  integrity sha512-GgXXBZJyjjdPp6zTi3ly3PcKFOT7LZ48iXEbIlsS5bxJzj0ISWL8MYSkALbccxNUxVtEt8JSWuk91buc+y0gWw==
+"@comunica/actor-function-factory-term-ucase@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-ucase/-/actor-function-factory-term-ucase-5.3.0.tgz#93ac592ce7a0fca6c080c23cb7d8fa58eb1eefd8"
+  integrity sha512-bwdotNq4cemUE/ryFaqI0XTqE4mR7cthUjkZ+Y1NdFVX/7JbFXH92xSTwZp6e6wWNALVJXjcW7ilWjwC8WsQ3g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-unary-plus@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-4.0.2.tgz#58e3552857995a20b9359159be9dc4b241a69032"
-  integrity sha512-LKjRV9/+NtMAd7kd3bZ32Rf8oqjDNENHzfu7a78zUujhOlJmk8nJCUOWDYXwgICHRhEcwEUBOrYzr3Tsqyb0kA==
+"@comunica/actor-function-factory-term-unary-minus@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-unary-minus/-/actor-function-factory-term-unary-minus-5.3.0.tgz#16d349b4262354b34ff2d25677c3000c9d5f68f4"
+  integrity sha512-Iqs5SCMaSDCU60rkgDVDlXlSK1VSOVcCQojobdX5fwMpfLRNfTSk5kiZDsFYZZ7givTcWtrhzwJdpH0xbL3snA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-uuid@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-4.0.2.tgz#055179cadb1afc4ac7ed1575fc172f90d2edee87"
-  integrity sha512-hW/B2g5rB0d1aCuO+ptO8VIOpll1IuAatR0MsxbLqBLgvTntzBXOAgM3X+B+6V7z8fUjPQBun2F1AIomlDtAsg==
+"@comunica/actor-function-factory-term-unary-plus@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-unary-plus/-/actor-function-factory-term-unary-plus-5.3.0.tgz#b3c2b7eb7a8f19d58df0d6fb886197862e79260f"
+  integrity sha512-Vmrf4sKYZx/p3cHvolVXpNySBB8egFFsK5x0CBLkjWknFMAaLQgJ+/VHCpAX3S4Fa2BxzEzfiReLZdzJaWYD3w==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@types/uuid" "^9.0.0"
-    uuid "^9.0.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-boolean@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-4.0.2.tgz#db0a638207cbb0519ae8e3724e0d0f3e0644faa3"
-  integrity sha512-Nt6VOnH+HNUpbYsebbAxbgK9x+CSib8aRTYUNycqAx0bhMLVqHR0yteCmvRfuWLLX3nsTUa50D3IJIXlrytBvw==
+"@comunica/actor-function-factory-term-uuid@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-uuid/-/actor-function-factory-term-uuid-5.3.0.tgz#3747269a8710bd5b0714e4d6471285bc233a0afc"
+  integrity sha512-pU1Bkb6wJaC9v+OFBQW5vPHztC7O0Z5qxyOvF1A+ACc70Cm+Vpf/dqQkTfGCw29J0QqtDvR+WDWcwzOpcGOw0g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    "@types/uuid" "^10.0.0"
+    uuid "^11.0.0"
 
-"@comunica/actor-function-factory-term-xsd-to-date@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-4.0.2.tgz#6047f5a9ebc0e8bbc2aa463fc881c8d3faaac6e0"
-  integrity sha512-pwcx9VVEqaD5kXpyYlb9WyOpXZKZfqpB2SYnU4MLZFAaRuju1PXgcK9pRQMTkZpxP2UaVrdF4sieSsPlcFA1wQ==
+"@comunica/actor-function-factory-term-xsd-to-boolean@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-boolean/-/actor-function-factory-term-xsd-to-boolean-5.3.0.tgz#52739da6ef33626cf49814e5c819804976d9abae"
+  integrity sha512-epMZs8+BF24LiEfx+oESctP6Yz6l2iee4etwi3U63qT8GdLBQ+K8yBYB12HeXd9jUBcx4thUGFlg5QRKWH8RpQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-datetime@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-4.0.2.tgz#ce497b31deb233a8ef1d639ec83c9449059fc9b0"
-  integrity sha512-JhHoQKbBdo97bm33fEeg1aw0lyUCqb/kr0PYQRWGNmkO2nnklPerXbe4q1rJ7IEQEm+rKBA5lWaHsNOR8ZBvew==
+"@comunica/actor-function-factory-term-xsd-to-date@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-date/-/actor-function-factory-term-xsd-to-date-5.3.0.tgz#4cef245a786583ec0f87fcad7873d794a3c3355e"
+  integrity sha512-fV5W3gExau7dp6OTQjCROjDhcUU9+rEBuY+clNi06IKEoKeza61Mw8aGExe+uz5PbmXJlo9HU1n1sHjSXnLY1g==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-day-time-duration@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-4.0.2.tgz#e735bf44a9ea109a5ca04c19bbab4968baa9cc44"
-  integrity sha512-SvLuHsjpC10gDIRbEs7yVAtThIdenxlX8sZyZh9x8pqv+5Z/q1gM04uR92+aDhi0C4XPh4na2zvhyLQQYAAymA==
+"@comunica/actor-function-factory-term-xsd-to-datetime@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-datetime/-/actor-function-factory-term-xsd-to-datetime-5.3.0.tgz#e4adad704a53ca0c6357a470d8d632441a2a4594"
+  integrity sha512-WhiWzCFFldi6ggYzIOBRHnLrXZXd7qnrXVwiH2b/qldaiCBpQ/S/OdaMWA3YeRuWj9UUyWQEJJfKDn6UOT8Hcg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-decimal@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-4.0.2.tgz#fd6ac0ae03790c213ed631a6202c9a6d8c330aa8"
-  integrity sha512-XiCwdX1jdVFodhGtp73GqGhTEnqEh8Izr4fDBotmnXuZ/CD+3Fl8iSlSR9ZZ9Qyi9WdP9PTFwOEAwzW5fwfB+w==
+"@comunica/actor-function-factory-term-xsd-to-day-time-duration@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-day-time-duration/-/actor-function-factory-term-xsd-to-day-time-duration-5.3.0.tgz#7b4d8a8be7cb5822536a07734445b9230c9198e7"
+  integrity sha512-Bnemng9tfPdEkt++vM9tnmkXAHy6ktcX5RbePK0V8lDxpyED8nwc/7fEMrYa2X0uFc40doxOOhiO5Nl3P0pMmw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-double@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-4.0.2.tgz#49995f35ebd0f77e23e81d5d88b3dee35aa9163f"
-  integrity sha512-ZLkyO9/J+RJy+neQjhlyn3NdCN0xIC65kyDc4cFvMnO7hxTuZ1wYx2ojuFG6kB2KIUM6L1Dz0ygNMXXaZ0fWCw==
+"@comunica/actor-function-factory-term-xsd-to-decimal@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-decimal/-/actor-function-factory-term-xsd-to-decimal-5.3.0.tgz#e38c71bce76c1e3a10fc9fe6cc56dd6138d41c5f"
+  integrity sha512-NrIwHXj1uLf7i+QgJMVnHqrSe0HGWhID/wBwORk6nrv+PFjI3ErBhvqzLapDbcmr0BlPaxyVx118lYzQZF5TQg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-duration@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-4.0.2.tgz#01abfa6f9a7a17450de2abe32f96b48b51106497"
-  integrity sha512-WhwI2clTaySPM5KFPy2UAvYciSlWJadK3q7WJz6ACqrf2FPtXB9DVC1T77ESu2ez2wVurFBcZno+m8+NZDN+Fg==
+"@comunica/actor-function-factory-term-xsd-to-double@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-double/-/actor-function-factory-term-xsd-to-double-5.3.0.tgz#b33f18d86cd90ff7176e913fb6903ba6c8b1a4c9"
+  integrity sha512-Fhqy/BiEO4XvSkh6vaOEuE9bPZm+kw0kd5XK7WklwYcrTjA62kXlKeJnOHy5JyKXLxNhF+ii5hjJ51WIKnujAQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-float@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-4.0.2.tgz#88ffe83eed99eaf44396c0ff9e0613b6ac23b436"
-  integrity sha512-OA9eO8LsInyBCsG8d4T4sQ4AmEWRYGvcttdZfyLquJTQ0Qzr0NA95CDDLPSHgPDPeIs2XsUVB4zPgJfP/tting==
+"@comunica/actor-function-factory-term-xsd-to-duration@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-duration/-/actor-function-factory-term-xsd-to-duration-5.3.0.tgz#b9de605491756ecbfb7c05ffa951f561565b5ec9"
+  integrity sha512-flpjFPFHL2Zmu3w+Re2AYvkAV5MK3JhysnRqeLR/+37wk4k113hf1UUCm8xt6rxg5fgSBlW7/7akfphEzGmHbQ==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-integer@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-4.0.2.tgz#3d55e29cec2f7f9e94a512a5715eaa1ae2a51135"
-  integrity sha512-oCBkxmygrJbTlJFJyVXhfnz1M3zQcSAtoMNLvcKnaOIPvt52pA7r7Y+PtoCPoshxviG+cqTp287qnWaPlh3OFA==
+"@comunica/actor-function-factory-term-xsd-to-float@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-float/-/actor-function-factory-term-xsd-to-float-5.3.0.tgz#f38f20f698b2a6c1b42d649c2dc05bf574968ee3"
+  integrity sha512-Dn9HLU13KkI0hnHoY2PRSLb8lj9fHA7ABHkhvHcg0s39SuI1VZva6GtdKOeDlJiUFOztjgDpyZXg6GpPW0c0KA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-string@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-4.0.2.tgz#645c93b3b53cf430c30e9474c8d1d58216f8f1a3"
-  integrity sha512-xMdzqfPJFWfBgiHyLVL+olL//vaLI27jLro4TCS+ycty+qkm2SFpV35qYTQ/McjOT/sLRf3FiM+6uSnSzq7J+A==
+"@comunica/actor-function-factory-term-xsd-to-integer@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-integer/-/actor-function-factory-term-xsd-to-integer-5.3.0.tgz#597611150af93f1670204c26ddb087dcb115485a"
+  integrity sha512-LbgcUNtZ1QVqS+cWUPH/tjeCpyhsWin3y2/5gt3susk2CgehBmt7XiDGm49V2hZwtfQRpTShBrkvDMM5fhTHXg==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-time@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-4.0.2.tgz#b75f3eb1c4a1c78cba9675077b39be75cd0439f1"
-  integrity sha512-w001S74g+GO5MbSaCuKvv/Je5hgxOL0Dsbvxv0Iw4u6ZXfAqyYHd87qNSiqoZAXOHJwBR3MgxmWFvV+Psd041Q==
+"@comunica/actor-function-factory-term-xsd-to-string@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-string/-/actor-function-factory-term-xsd-to-string-5.3.0.tgz#5f16689abbd8e4715f99d9c9ae16c343531b2506"
+  integrity sha512-vNXIcD2DCnGjPnaW58IMORI//bcfYTcHQlK/hvgbl/Ggrw3O/hGRwtMdrBt8wRQWbd9/ylBOrbIJe6dFer0Dcw==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-xsd-to-year-month-duration@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-4.0.2.tgz#0ae8976784f5a24c3b910247d04493fed40592bc"
-  integrity sha512-clsKU3IBekhkkNpoIdVcwNPmYTCZR0mDQgff6OLh0bqS/k6kHX4EB3ziAr60OVsEZupNlnjToyPdnBJD5AQbFw==
+"@comunica/actor-function-factory-term-xsd-to-time@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-time/-/actor-function-factory-term-xsd-to-time-5.3.0.tgz#53f3bf6fab2871fe0a6de5456b403a4b18001a2b"
+  integrity sha512-fCRzgcgY6aNn07fGw4YpsUsYcEASJewWGIK8M7XNJqt8ZlJmxEgLpviLuzYpJkMUq85gM0XlH1zfMUkEl17ViA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-function-factory-term-year@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-4.0.2.tgz#dd95cd57357a69e9aa83b5eb0dba7add916dc060"
-  integrity sha512-WpPYA5UmrZ4E/5MHBila2gUEdliIn86po9g7yqnzHVr7+FFOsi9vY8bHm5xzYcdT3ZPFKDcee38i9C6hJzYJzA==
+"@comunica/actor-function-factory-term-xsd-to-year-month-duration@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-xsd-to-year-month-duration/-/actor-function-factory-term-xsd-to-year-month-duration-5.3.0.tgz#5425c57da335d91eaaad998e1f6a033a1921b9cc"
+  integrity sha512-q+qKRm8Cni2x8GN+rNtTrPKzjv6eEWkMaR6KwGVdkt89/PKcj8exX/xEDlHuV3smUt8FwVUALL8zGGQ22wk2gA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
 
-"@comunica/actor-hash-bindings-murmur@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-4.0.2.tgz#b931a84853f615707f2aabf22214c1dfce3fb7ae"
-  integrity sha512-Z6BqvQtkesJAXw2aaWsZ5toLSVEf6wVt9lL4gBeE6OmsoSmZ0kJ66douVgDz2KgxPI28trYrVR+dH9YyF9G95A==
+"@comunica/actor-function-factory-term-year@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-function-factory-term-year/-/actor-function-factory-term-year-5.3.0.tgz#919629e5acbe1736c1f63b6129bf72f32c4465d9"
+  integrity sha512-/FLzdcP/sIdmOjaRqDwo8gfhp4CajNC/QEPxcvMaM5awjIgAJ77xxmgIBwIVBD5PUQMVTQQsZ8eeicm4TLSxaA==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+
+"@comunica/actor-hash-bindings-murmur@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-bindings-murmur/-/actor-hash-bindings-murmur-5.3.0.tgz#8e39be8ed201cbb8af0bebb15e2db316a4ada95c"
+  integrity sha512-fd82PmyTl6B/XJT0Ny8y8Tm6D6dpCGNONfox5E07nA12won/ot7YDdE0UyygHvq1ypIWnWNmnO7HirVzGDJkkQ==
+  dependencies:
+    "@comunica/bus-hash-bindings" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@types/imurmurhash" "^0.1.4"
     imurmurhash "^0.1.4"
 
-"@comunica/actor-hash-quads-murmur@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-4.0.2.tgz#f8d7e2813a2d97bfa5aa0e004190bb96f15d1b69"
-  integrity sha512-DlLoLQc5aPczWI+DKtEXOjfy95wGKTu8NTlTJZr0oWGK3xuqyRxXXIacymyoaWlEIQ4KeJ1ySbyTX4eCOvq7Kg==
+"@comunica/actor-hash-quads-murmur@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-hash-quads-murmur/-/actor-hash-quads-murmur-5.3.0.tgz#bb446f7f2a4dd24b0f6fd646fece4a6dcf66ad89"
+  integrity sha512-AhqeHlcfxTzOz3Y1EuaDlDi6/WqyCOQcnZ61TegIMlQXA+JjntMtefYkAdysdWEppB63LohAcp+hvClVsTh6mA==
   dependencies:
-    "@comunica/bus-hash-quads" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-hash-quads" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@types/imurmurhash" "^0.1.4"
     imurmurhash "^0.1.4"
 
@@ -1490,7 +1511,7 @@
     abort-controller "^3.0.0"
     cross-fetch "^4.0.0"
 
-"@comunica/actor-http-fetch@^4.0.1", "@comunica/actor-http-fetch@^4.0.2":
+"@comunica/actor-http-fetch@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-4.0.2.tgz#2d79f91bbfb83a28cb69e0c4f8813fd6e5c7d2a3"
   integrity sha512-otMv4WOWPrTfs4/UTr4tB2BKCIz2r8ncH2pTfQySQpn6KstlxPjWLAKy8ZKVgEg+E7jMTpgm331kwMqUbl2M9g==
@@ -1499,6 +1520,31 @@
     "@comunica/context-entries" "^4.0.2"
     "@comunica/core" "^4.0.2"
     "@comunica/mediatortype-time" "^4.0.2"
+
+"@comunica/actor-http-fetch@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-5.3.0.tgz#7528608df89cc0af8cbb1cc335e6c179ca717f0f"
+  integrity sha512-48ogepU9/BxNHBokUz+0iuKJZ0SCBNSqa/qQ1S0jEm2VtGPhOOCke6ght6Sal4HvG/SgYkZ00U+qjKWDl3NWVA==
+  dependencies:
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-time" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@types/http-cache-semantics" "^4.0.4"
+    http-cache-semantics "^4.2.0"
+    undici "^8.0.0"
+
+"@comunica/actor-http-limit-rate@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-limit-rate/-/actor-http-limit-rate-5.3.0.tgz#cd39c002dc31684de33829290daed48b6d4a8a27"
+  integrity sha512-7ZU2Ea5IYsZb8WHYc1ANMv7s/SAzWtnvbT53safoGAH9B9Mi+7bSvsC1pLNuYCVdh5HaqQ9zYHol4hqlL4om2Q==
+  dependencies:
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-time" "^5.3.0"
 
 "@comunica/actor-http-proxy@^2.0.1":
   version "2.10.2"
@@ -1510,7 +1556,7 @@
     "@comunica/mediatortype-time" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/actor-http-proxy@^4.0.1", "@comunica/actor-http-proxy@^4.0.2":
+"@comunica/actor-http-proxy@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-4.0.2.tgz#78e170c3ea7f5aff1862b0df085096adc82b6457"
   integrity sha512-wIwAXt7kO289u1KIBL2NWY13kMo593weBQKMvP4OFpUHez50/631mMZz8zSLRlsM+KyPhXmPT/RozMFkekojLQ==
@@ -1521,1297 +1567,1481 @@
     "@comunica/mediatortype-time" "^4.0.2"
     "@comunica/types" "^4.0.2"
 
-"@comunica/actor-http-retry@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-retry/-/actor-http-retry-4.0.2.tgz#aeb07d74c97af3c93e039cbb46073625e4b16b1d"
-  integrity sha512-2PKEjIeFHY6+/dIaJFi9n3Ax//J5s0p3Hq9OGi7nAHa0dn53RnKRBOpFhor5LLKvxtL28iLlGxXB5UY+s/zZhQ==
+"@comunica/actor-http-proxy@^5.0.0", "@comunica/actor-http-proxy@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-5.3.0.tgz#45a1ea90e98d26d858be2df172829d263ea04439"
+  integrity sha512-XzIDfH5Jhg2Q63vpUb4gyltaHqWeg00Pa1Oc+qdOREzy71hi6lsqQPTXdfh2zrK7I61PGvBB9DKpMloY3MObkQ==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-time" "^4.0.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-time" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/actor-http-wayback@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-wayback/-/actor-http-wayback-4.0.2.tgz#5733830de913f521f0b36d7d9819096cb751be27"
-  integrity sha512-XzryGOBTuwAmDUzcj3WUvOOu0cmO8XD66bd2U7zRLdrkFRMI8XqbEaxx+ycijIEy5wGusUgolbUH03CjKdHhaQ==
+"@comunica/actor-http-retry-body@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-retry-body/-/actor-http-retry-body-5.3.0.tgz#5092dad654e0c27f12154865fc8ae3067e8abfa6"
+  integrity sha512-4qMkFXpW+bfcsL85XroQlIkXWT2MKtKgdls7KWrr1aqF9oBDP0EnLPB6bLSv2tNmYhheE+0ANbe0X5HdqtXc0Q==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-time" "^5.3.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-http-retry@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-retry/-/actor-http-retry-5.3.0.tgz#2451f1857f213765c5bb8c208a3718a549ba15b1"
+  integrity sha512-Fp+Rkk6zEzjwnO/6SmoKuQPMUvntAmj0pXk50aaPDCLMm2+kaHnI26sAESVQZ8wVXUMDZxx2WZ6Y+PBTomrv4g==
+  dependencies:
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-time" "^5.3.0"
+
+"@comunica/actor-http-wayback@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-http-wayback/-/actor-http-wayback-5.3.0.tgz#cf8b8013ff043a84ffe69a5bcdf6838fac7b6f85"
+  integrity sha512-odhxd9giyEEuyAWFaneu/YVlXiAOYn6p2NYwWW4SGZWCr7WCo70bIiL5xoVY7BI6Bfu6Hj1jW/6YN0bo7UtkOA==
+  dependencies:
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@jeswr/stream-to-string" "^2.0.0"
 
-"@comunica/actor-init-query@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-4.0.2.tgz#369d2a8d58907ae1e08004561e26c215f3dfaad9"
-  integrity sha512-3/PzaoWjbzN4qaZD3fD2rxpe93jgjcMtjV0nNScmlfI//A4ckanHAN/6AwAhJokjYHB+KDkV+5es2gMeZxiR6A==
+"@comunica/actor-init-query@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-init-query/-/actor-init-query-5.3.0.tgz#082ded3aad3999eddfb9e76076ff9c585f16ae80"
+  integrity sha512-57nD6J9g4hPTM9XX8HA4F07q/KlW6YfbmIyqZuUdLz5IkT1my8ceoGkNdRBQyZmjN174ChZUCZkBuR+oPzBVWg==
   dependencies:
-    "@comunica/actor-http-proxy" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/bus-init" "^4.0.2"
-    "@comunica/bus-query-process" "^4.0.2"
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/logger-pretty" "^4.0.2"
-    "@comunica/runner" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/actor-http-proxy" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-init" "^5.3.0"
+    "@comunica/bus-query-process" "^5.3.0"
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/logger-pretty" "^5.3.0"
+    "@comunica/runner" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
     "@types/yargs" "^17.0.24"
-    asynciterator "^3.9.0"
+    asynciterator "^3.10.0"
     negotiate "^1.0.1"
-    rdf-quad "^1.5.0"
-    readable-stream "^4.5.2"
+    rdf-quad "^2.0.0"
+    readable-stream "^4.7.0"
     yargs "^17.7.2"
   optionalDependencies:
     process "^0.11.10"
 
-"@comunica/actor-optimize-query-operation-assign-sources-exhaustive@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-4.0.2.tgz#c184b736d37a2c7f4d850b4e5ad2c9e634e9b3da"
-  integrity sha512-jB4hx9mC3Acg0IhH3mfARNk1nlcn6PC31pxaFLrqHA94HY0MOFmyRQw5e4a7/hrFkQOeP/RO4nEzYkim39niTA==
+"@comunica/actor-optimize-query-operation-assign-sources-exhaustive@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-assign-sources-exhaustive/-/actor-optimize-query-operation-assign-sources-exhaustive-5.3.0.tgz#feb9e062dc29d868177b90ce5c06ab0e4d90cecf"
+  integrity sha512-PX42YLREzgZcZ5Lz0Kdxp2OZYM5qEIzFqK2tUZ4pmIdfqJD2nqss5fIDwWChO1XZVjFE55/+TvykCTyPWBddQg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-bgp-to-join@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-4.0.2.tgz#0cfcf82882faf307d1d4abbfa6d2c18e215d5fb2"
-  integrity sha512-toNMxgPj2QE22voNLyjz0JvWC8LUNJNqlQm0PmORiZ4Oo0y7aapWbimsbb8ODiUNzk/yA13lw4RoC2rXT8ZiFQ==
+"@comunica/actor-optimize-query-operation-bgp-to-join@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-bgp-to-join/-/actor-optimize-query-operation-bgp-to-join-5.3.0.tgz#846f6d5dd99b4b129cd236ef339437c434a800a2"
+  integrity sha512-n6ss2cRvdg3wyKdGC/kp/px+0geAvkk24Ob1dDdy4+7bosSubhbFmMH0azpwApvqWETdbZQznhw+MW+YN5JeVw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-construct-distinct@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-4.0.2.tgz#6c180fbc86912f8f5fbfa20a230d48a826c7fdd6"
-  integrity sha512-0gX0HgIdxIzj3HKPxT9yArKGpz3MC66vy8fhEzfCP/RKeIhH0+UC2ZkSmAVNMR5Zi0gr8GsvEoFAxukxewgWIw==
+"@comunica/actor-optimize-query-operation-construct-distinct@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-construct-distinct/-/actor-optimize-query-operation-construct-distinct-5.3.0.tgz#2d56cb5435337380ccdf6df774fcff2fde030bd4"
+  integrity sha512-bM1g6HC2+WKPrtjD5x1FOI0OYgqfN7d+0Ks+vW/uSFC5ag0e6mVH/GeSRjby2PSd+Vmi2EAs8xnshq45T9T7MA==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-describe-to-constructs-subject@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-4.0.2.tgz#9b904d8f51a4619321dc720cace820ed5c9cb663"
-  integrity sha512-NaTivl2s0mNcKMtNRyI9dmuazGCdu4giyNcdoXDOo6xmpW9XwNWSeVryoegnuuuRH+ipTIe3okMUjMMgc/hFUQ==
+"@comunica/actor-optimize-query-operation-describe-to-constructs-subject@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-describe-to-constructs-subject/-/actor-optimize-query-operation-describe-to-constructs-subject-5.3.0.tgz#3dccb1326ced249949099fbac35e4b62065695bb"
+  integrity sha512-+tg/JKfHZMVx5zRBH/taZP1J2zkJlPRWnwGTB6T7t15OXUN+zAcTMwf0v93QfN1wdlRY2hPqJMMi6BTUJMV+DA==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-filter-pushdown@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-4.0.2.tgz#ce939a1ae08c05958aa0902d42a8e665b999e5db"
-  integrity sha512-OkzHiUN6jW02r9VbWTkgHan2dFNohtwqR+8rhPH6LH6EKEiF9TlsWJDI9wXIIlP5QggW7sjhixXAx3bwx2Pa0A==
+"@comunica/actor-optimize-query-operation-distinct-terms-pushdown@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-distinct-terms-pushdown/-/actor-optimize-query-operation-distinct-terms-pushdown-5.3.0.tgz#8221044e043d03cb812d59c84143f5dcc72c7e62"
+  integrity sha512-1t2dXxAcFMNj+sltazjM2MawOKxPWjq7su6i7sSFVwU2iyBBF6FHGYq7AZHEcgeZZESepu1Wc1N6cfwIigiUUg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-optimize-query-operation-filter-pushdown@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-filter-pushdown/-/actor-optimize-query-operation-filter-pushdown-5.3.0.tgz#95ea3495ce04fe28ae2c76887917975d54bde2ab"
+  integrity sha512-qEHY1gL5h6SdXi79s4JGPZKrDdzdtC3mXRX7JfRaxcaS6RvUT2Nfqf4HCEhz1VT5dca2NfV4bLMdVIHiHevdmw==
+  dependencies:
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    rdf-terms "^2.0.0"
 
-"@comunica/actor-optimize-query-operation-group-sources@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-4.0.2.tgz#4beb687bd5d8b0d721b40cc376cb84b874498207"
-  integrity sha512-cW+zh3gE7DLesja5LRXCfwU2G2nfl8aCr/xeDNn3e4noN2okaKOPCa0jVw7sbzUNzKEeEtTW7mqlyPaj0n6aVw==
+"@comunica/actor-optimize-query-operation-group-file-sources@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-group-file-sources/-/actor-optimize-query-operation-group-file-sources-5.3.0.tgz#ecce5b5fbc328f924255eb0272f1c9f33cfad448"
+  integrity sha512-/7GTHmbimaAgWCnnuP6BH4wvhMWvUlgYiDyei6fjYtTlKG50oAhUmDcGbt3awsA/xgHfBhHLVXYghdNcTLn0jQ==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-join-bgp@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-4.0.2.tgz#2d00d5c467c4982d3a7968e37db47c7704eedbb7"
-  integrity sha512-qqTfb/bGLCBIF4mpwSFBZWtUHqDriW5NussdvokI95xza9hLz3avlz0XU4hl0IXCo0FALpdXlhO2WZfUDH3dEg==
+"@comunica/actor-optimize-query-operation-group-sources@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-group-sources/-/actor-optimize-query-operation-group-sources-5.3.0.tgz#21669bfdfac8a95541769387ccc7905d51a826b3"
+  integrity sha512-MYQG9QbSKkrxct4UH8Rrs9BV9F2KiXtJakApabZ4o5Nzn4cbQirhc1nZY2dMZyT9M5HLDauswfHUWBGsrto0zw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-join-connected@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-4.0.2.tgz#4c08b2d889557f3bdc79c72dc9fc9c41612ff529"
-  integrity sha512-MGIRMqAK+A41j+8y3qNOYj2QLc//wJ1UVqGWIIzsBFiElCmas9lBgo8KXa3kj9V9xLRvSSOB3FnBLVMByYI7GQ==
+"@comunica/actor-optimize-query-operation-join-bgp@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-5.3.0.tgz#df4ec28a86112842f859a8739e69ce85af945dc6"
+  integrity sha512-kImYzuGpH6FE6lJZPqP23tyfTiJzo46Wo6X3oiePri79tLmlVaulADqUKTRrOZHNFTQi4F0L3MI2yaMJkrHifw==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-prune-empty-source-operations@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-4.0.2.tgz#ea902c94092b98ae4611132e8c4bfa02ee1f82ed"
-  integrity sha512-1axwtflbHHCErfeKpqA9e9wOxsxsgE8VKvNw3S6PRMq0+ZVyecDeaZrsiaSdjG/0ovmmqEihYipG20/WGoamYw==
+"@comunica/actor-optimize-query-operation-join-connected@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-join-connected/-/actor-optimize-query-operation-join-connected-5.3.0.tgz#31ef2983fd602538d6a77ec8d4a33c58db870fc3"
+  integrity sha512-Iywr/GkLf/wmruAv9IGEnSDqEyzmNcZudHVR5kWS0YF2RLzSt4t0PX/VGd+iZoOu5nGpYiMbRONJr4EAOhoGRA==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-rewrite-add@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-4.0.2.tgz#29c43748b56b6ff09626e4a201a49ee1e5b2d4a4"
-  integrity sha512-Y+MAA/k95uOA4nbwtkVEWQGhZe1XSr51/DUtm8h2w0Nz34+RLJrEKIvPJZXiWhiCxtdImt2YXlJwRxT5XuVqXw==
+"@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown/-/actor-optimize-query-operation-leftjoin-expression-pushdown-5.3.0.tgz#1dc97dfd2daa5f904608be72085c57b8455baea0"
+  integrity sha512-U1q9CeRNB0Gcdbhq87G5zMv9lyBL8W3qHi+PLn/K5KZIw2W6B2vMGbdmiXmYxOMeTxpHd6pJIK/sX8EBikdrug==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.2"
-    sparqlalgebrajs "^4.3.8"
 
-"@comunica/actor-optimize-query-operation-rewrite-copy@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-4.0.2.tgz#104a0d8e10269b7fad9b0107b6fc873ee809574a"
-  integrity sha512-7R68KOrIDVj4XqMvIfRj5Bun5gwfaqKmN4qBY7eWWUquw3peeImNia8opYALb9T+/C6jH76zFiArGS3icyN8Mw==
+"@comunica/actor-optimize-query-operation-prune-empty-source-operations@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-prune-empty-source-operations/-/actor-optimize-query-operation-prune-empty-source-operations-5.3.0.tgz#3ef5715f9b257eeff2627341888130a93f361473"
+  integrity sha512-DWSgeL6y2ph5ia/8vlfj3TSIniCwyKT2LSPwsSIpVdn2MkCKw80p6jxDbpdTG1mLqEXqz0Kjp25jgVGoW/CdYg==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-optimize-query-operation-rewrite-move@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-4.0.2.tgz#0fd906051e72c0934424c4e754615473cbf04b71"
-  integrity sha512-doAweQ9pv6kgXWI79MPk7+zXbGNNRSHZHf/RGfCRFa8IdY2A2Dd7Ka2JclHRDhkpCxC1RijOkd1XFmYpwsMCfw==
+"@comunica/actor-optimize-query-operation-query-source-identify@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-query-source-identify/-/actor-optimize-query-operation-query-source-identify-5.3.0.tgz#40d14527d30f0c97ff862f331056ccdc41bf033a"
+  integrity sha512-jvU5zrpJj/32F6fQ3G1VU3QhG7xpXlfBWk4tKKdbs+d4hbwBS0Nn34/utn6DWiTpOUIWuGpio9Z2uQ4VJMHpyA==
   dependencies:
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-context-preprocess" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    lru-cache "^11.2.2"
 
-"@comunica/actor-query-operation-ask@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-4.0.2.tgz#37b2c1ce06b7fb73de177911b6555180866d61bb"
-  integrity sha512-MbmwbdR7kK7MwMS/uPiW8mzr5u9gkl7pRIHK35IbwRh4B+m3Jv3zCWZPY6I56Wx+7c729iN/EV61ZBOH5mKQ4g==
+"@comunica/actor-optimize-query-operation-query-source-skolemize@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-query-source-skolemize/-/actor-optimize-query-operation-query-source-skolemize-5.3.0.tgz#368aef6622e04dda5f249cc4a0ef096964775014"
+  integrity sha512-utQuZ0ED6Bc21/jblXi15Ec+dO4OrAtugZDpP2TKEeousDh3fCgnEGTAuAfcpbkdJ8/4Wft8mv68YaoqVWv13A==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-bgp-join@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-4.0.2.tgz#7325001bee6a0077136a378f219bfc1d6b17a656"
-  integrity sha512-PBBZr78TsnbyA2Iscb6NB0TfnrIHwNuvyIwR2UUrpL2wnipgD1gt8GQv0cND9cRGMfZTr4cW7vG6urrNctJCfQ==
-  dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-construct@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-4.0.2.tgz#ec26651125b40cea8b4858410ba0e0a5dc4fb55f"
-  integrity sha512-KEqPAuRgCG0uaFelln0naRFJO8mcuB9PzJMwDRqDYc1nGWiVWxt0ZYP2vtCsor5jqEWAOYVyctp/Oq2UUCqElg==
-  dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-data-factory" "^5.0.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    rdf-terms "^2.0.0"
 
-"@comunica/actor-query-operation-distinct-hash@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-hash/-/actor-query-operation-distinct-hash-4.0.2.tgz#df0229bafb1e795acf262d209da46bed2d3a6280"
-  integrity sha512-CylA8fOU/93+w/5bhSmxaEr7E5xUtXEy6XqLEfM4V74QPfOjydBnZhVEgajLCa/Z68TH9c7PgpB16BpW84+XQA==
+"@comunica/actor-optimize-query-operation-rewrite-add@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-add/-/actor-optimize-query-operation-rewrite-add-5.3.0.tgz#fbd44e37ed8a5c829efae55117ed5205fdc2ccc6"
+  integrity sha512-Uh+dZ+8BlUcyd9LBU6OmhmLNorNzv9VUc81BQhMAcEyJPjMUHZUDpGtBRqne4BdSYF0/08dxx52QerPcp1+13g==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.0.2"
-    "@comunica/bus-hash-quads" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    rdf-data-factory "^2.0.0"
 
-"@comunica/actor-query-operation-extend@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-4.0.2.tgz#e933695a661511d6a3137474c84fda6da5be5055"
-  integrity sha512-9YRIPPFE8p6FysH8zf+ONTxfterlldDAcn7xqSNuyZywTCF7fRXV5/7Fiym5DWjVIwZNNaxw0fe8CPv/yoVklg==
+"@comunica/actor-optimize-query-operation-rewrite-copy@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-copy/-/actor-optimize-query-operation-rewrite-copy-5.3.0.tgz#d151175b6b461328f9e3e288101986a417c760cf"
+  integrity sha512-Y3oGFfn14K4J4MAMvuZss43N9MqdJhkCShaTFJk96bm4FWKRPhDNJvQ9sMf/lMprRIocOO+AP0gA+J1UWKg4rQ==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-query-operation-filter@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-4.0.2.tgz#02a96f1115fa6b026ccb38c7283cc775e46d216c"
-  integrity sha512-I3cpMRlWJM29liEIQ2Z+0V5TEHZLS2OnUOhIbWkojxWYyPMFt11Nqq8V7+loVU6KWVDocJua7LiBp+UkVGc66Q==
+"@comunica/actor-optimize-query-operation-rewrite-move@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-optimize-query-operation-rewrite-move/-/actor-optimize-query-operation-rewrite-move-5.3.0.tgz#3e9c3e3054d9b24f9f1d9bc35cd08ea1a8dfa91c"
+  integrity sha512-4gHdgEvPNosME8ecYBAFGUd9jw6Cih1At6NdhoPIWG2To6RAyXbYNA4Lj+JymiFl/HDwz6pxC60o/Y17QvOIyw==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-query-operation-from-quad@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-4.0.2.tgz#721cb631a9c545bce1e7bbe2f289d49745f65fed"
-  integrity sha512-HkwhPVt9rzGUBMx6Zqb8uA5FLpVkqE1iK3QA8TumE19rK7DGUhG5jpaZr2/UMwdVefaWS0NrRh7bOWOC56UjuA==
+"@comunica/actor-query-operation-ask@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-ask/-/actor-query-operation-ask-5.3.0.tgz#4f832ee0e78d11b3a216c77198fb65cb85ce5ecb"
+  integrity sha512-9ozBM6K5VLQsD3mZkOoE6NH5jITghM6EtmB9+0DZlk/k9HF+TbhvXkh8h8NLo/mY05urrYsYyl8YgjN9X/ZtmQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-query-operation-bgp-join@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-bgp-join/-/actor-query-operation-bgp-join-5.3.0.tgz#5adfbdb452a94fd949e35feabce278744cd7fb03"
+  integrity sha512-8veOnDvl6HZdHCCoy+VIX9WlQdZFlndCf2bZQaCBYt9Rgcu7maMfx19sDmwFK04fAly73dws35l2VZO7v6TD9A==
+  dependencies:
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+
+"@comunica/actor-query-operation-construct@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-construct/-/actor-query-operation-construct-5.3.0.tgz#fe815d23881e20f7776352d162ce08e195d38ffa"
+  integrity sha512-I+V1jDXwWm6Pfxd4csbB0Gjjci/NCutKSr/GS1nu4SGdWxaL9oQDVjBtwaklnYA43iAUsl5vB9j5wuhtCyj/Kw==
+  dependencies:
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    rdf-terms "^2.0.0"
 
-"@comunica/actor-query-operation-group@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-4.0.2.tgz#d5c07ea62d681efeebd43493462c10bf3b349e8b"
-  integrity sha512-LZ38sHy3p8WqWNYZpUi/ZqpcRAIFM8j51pvAqiimCwKKK7dTf3MRRTQ1lfCv0AS8VYeSj26jwm5yoPqOyzWwoA==
+"@comunica/actor-query-operation-distinct-identity@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-distinct-identity/-/actor-query-operation-distinct-identity-5.3.0.tgz#0a0bc0bf86174ac7e9d6cd0aedb9eaa6acc5e10f"
+  integrity sha512-xiTM6zAvaXOL2ubLpj59jNeBbcMXTGWl7oip/2zfyOwr5EA47jgRkHbitWlqrpIbOVJBjtOlGXJVGH2u3Hdf2A==
   dependencies:
-    "@comunica/bus-bindings-aggregator-factory" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-query-operation-join@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-4.0.2.tgz#eff1b27e44aa07c648f27111fbdfeeb0e656d84e"
-  integrity sha512-o7AxCpY7spJNliAyX5+hZLu9Sc8+TXpkdceEAFu8HG+FEQjTFS+Zdn6XIBR/++PLUYpmtQLkeUFrOsIvNELcQg==
+"@comunica/actor-query-operation-extend@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-5.3.0.tgz#21bf81d26b8678e5c79482c21a21da82c0ef9d0b"
+  integrity sha512-Xv8lfdDRqOtoA06YBUgrCaXY66js7Lhll7v9D5Tvkso3Mszsk1GCLnVwWgiMIkWK5qd+ZD1yoo8+f/UIRe953w==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-expression-evaluator-factory" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-query-operation-leftjoin@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-4.0.2.tgz#a7d6910789bb5dc964de7e0067f18ca633023395"
-  integrity sha512-dISqBEJMu87Vjo0TE1L6YmmOhmTM3RlbnIi3hVyg94foUu3hMU6KE7uv/7jD94dCoD7Q6wVev+rGdPD4O6Dk6w==
+"@comunica/actor-query-operation-filter@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-filter/-/actor-query-operation-filter-5.3.0.tgz#9e9fcc4796289f55ed471ca2de7eb3716c29fe4d"
+  integrity sha512-KNHa3ESOY58EDp8MrknzBVirdYkgQa335jpz99edXoJ48YJSlsWUbQpVR3MwHri3aGjK9V6LV7cQn8oU5DrfbA==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-expression-evaluator-factory" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-query-operation-minus@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-4.0.2.tgz#eedb7723f5180dac1b2e723e371d8c494a189ed0"
-  integrity sha512-Hj41RX5pZMtIazRIkrH5jaTY/1IKPuCpomUu0tOsIear4A8XRaEB8zcF7Eo6lDEme9rTedwRm1X2hkvMi7lOEA==
+"@comunica/actor-query-operation-from-quad@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-5.3.0.tgz#e63da1ea7ff579413483a6bc95dc0cb761a94074"
+  integrity sha512-L+vl1QVIi+wPZMEb0Q6SWAJ2GYvPpsNPztU73EGTRsLuo5rePOCg47V8iz1Nj5psNv9IVW+e9bdA8R7ACY1FdQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-nop@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-4.0.2.tgz#1108b9a146c3ed99721cfa79594210fdd3ccf6b4"
-  integrity sha512-Y2viVLHS5mRMrq0UIt0vEOYNJe8n7D0Ato53a7cNIZFQZHz1AYcTxWlYkab3ctjtIwlgvmMuvcD1dACgGD3eDQ==
-  dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
 
-"@comunica/actor-query-operation-orderby@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-4.0.2.tgz#6b9358b98e67641816a375ae1eae71c20d2273b3"
-  integrity sha512-YOzPTrJ4yUWrWbTmLPOWLdVWt/9NGmkBs0Zn/k1ZcABZHni0N+DbHJGcwc8jWs0siQD8ifUTPM6o2Fkz8b2MxA==
+"@comunica/actor-query-operation-group@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-group/-/actor-query-operation-group-5.3.0.tgz#17568ef9d7494ab286781c4bca3d92e58b4e0801"
+  integrity sha512-TGBfjuVECdGCF+AUIPfc+Zv6c4EXSEKVQoXRcBuAhK7YxXd/U74uurar6KnoWjgc61IsNfuS7J3t567IKZ+oNg==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-term-comparator-factory" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-alt@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-4.0.2.tgz#1ed98814dc103bad1b2b8b747b18090ffb0a9536"
-  integrity sha512-SYpAHoKqwwHykE0ZLU34cqeHG5RakpO/akbLdr6sXsvNwhooGYQRyREMRuGVrIpVbLebbQHHUCSum7cL4tlPWw==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/actor-query-operation-union" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-metadata-accumulate" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-inv@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-4.0.2.tgz#8989b5729c9264de984936727001db6ec39613b8"
-  integrity sha512-eitaWnmfQ6KXaJSO0V+lM9HYcm0zDJ2703ltZGuVcW1GJfLAzF9E0c7hIsb2L9hfviEFVYzkne3jNr5oLh28wQ==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-link@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-4.0.2.tgz#369e9873aa3fbab9613ab7133baec39be496e145"
-  integrity sha512-VprtFgeyiuS6zKurAej7Yhg/hqt/5xrR22yLLfNqG+huHXD4uKkHwiOkansOxiRpp7fBtWniJsfnSmjxOa36TQ==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-nps@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-4.0.2.tgz#3dcc824f5e7a6fc983faeb7562b3076e7cdb5eaa"
-  integrity sha512-dST+fHDy9RpMkWn3o4h73xQJ8+pDJg9sGXwilmH6/ntHtvd8yYLBPDJq4wNRwpw1gr0V4kMEwl3dIK2RZdZ34A==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-one-or-more@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-4.0.2.tgz#57b4590fcb3c143930fb7168e57d5b6a503f1abf"
-  integrity sha512-njgpodJzQeKEjmkuOrnWaVFHw7qwGF3sC3ZEB5kUexf0ZzgYfBzfJEQIOBYNl5ZMFSKzQ9Su0FJdUiqjeKWXjA==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-seq@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-4.0.2.tgz#7ccd46e4e9befd74e62e52ecd8d4f672ba0a099a"
-  integrity sha512-rMX+yCBcd7LqS6Hj+jE8X4yYWsmf6myvTtea1NiSaR538ZChH5RM+vzBM6w8mZ2BO4F9ukvI6yCiRrGtWV0B1g==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-zero-or-more@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-4.0.2.tgz#aa29170af3395f1c8ad4228382579f8b75d6bb38"
-  integrity sha512-J8gL+R8y4IzHdh57jOmR8NU5ynbvjpstm7W+6yrDUqsT0KAO0f7l+ybwmXImgks2Z/dY/CGHxMYm8NunNhx88g==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.1"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-path-zero-or-one@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-4.0.2.tgz#61ec1a40efdfdc508c2869051c8460c571583d91"
-  integrity sha512-J2XwPuN4RpBwzKI2zUSIMA5RRs8MAHUK4pg/1ryBJTimrPMoccjYUN2bPoPDlVAUhMJWRVuu1oq+wRHy74WC3w==
-  dependencies:
-    "@comunica/actor-abstract-path" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-project@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-4.0.2.tgz#b6fca6f0f8d35d03854fcdca4c6d93bf410eeff4"
-  integrity sha512-ZtMeTF4L2y0/Wf36dPKg/weO7IPUIjUPqQV7vPyD2CMYnnirHoqBxNRUUvgsFPDr+eoVdljt9ileCQpA1o9o9Q==
-  dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-data-factory" "^4.0.1"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-bindings-aggregator-factory" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-query-operation-reduced-hash@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-4.0.2.tgz#f128a7853766e8385e3bb892c54159201c0fc0f1"
-  integrity sha512-8O+U7IpXf4WNEs9wNJnIebjaezXACwUXpvAEydzPUhuBIfTYCPkWio0llXhpuMZowelF9KVtP5P1H6eJ5jph2w==
+"@comunica/actor-query-operation-join@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-join/-/actor-query-operation-join-5.3.0.tgz#af657fa9d8965556fbad8dec73cf5508135c2a89"
+  integrity sha512-CcHxkuaVUg+5K2UkhrMOZ3m5V7cGhMgQsqu6N2N+Y+g+QjJ9Nsm5xsSRJuu5jGM8MS/40sXUXuBArJNj/Sx63g==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    lru-cache "^10.0.0"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    rdf-data-factory "^2.0.0"
 
-"@comunica/actor-query-operation-service@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-service/-/actor-query-operation-service-4.0.2.tgz#f2a59e90e6128bc0684fc97d041875834e0f9757"
-  integrity sha512-bPZCcSmciLV06DqEM3f8r1jBb5EWdGLFLA1BbdHVjZ/EmfiRY/3xzZJoq4qoEzKnyVZ1iDr/OZA8CIiuAVCU2g==
+"@comunica/actor-query-operation-leftjoin@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-leftjoin/-/actor-query-operation-leftjoin-5.3.0.tgz#3d73e20a80997969918c801b4c6d09bf7e35de78"
+  integrity sha512-6NhfaXJGM480CSpFnjlJm1s51YJdzfVaRKkRLQ9shIPeWiDgQfVo+IJm/WMchYUFYs1RYAGUU4z0e7IEgcbhjg==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-query-operation-slice@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-4.0.2.tgz#8517b425acee4c0abdb7d49689dd8b57f1f3efa4"
-  integrity sha512-26lY2nn3zFeZ1DF3jm7Fv9fRSKMrr3Utsl56Y3yfn8809Its8m3yOiSINOJ+Q9J3J7jZvFqKP0mbvKZbTHQBUQ==
+"@comunica/actor-query-operation-minus@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-minus/-/actor-query-operation-minus-5.3.0.tgz#0ee753ac7e011acef984d0b70f6b4373ac42787d"
+  integrity sha512-1pyEv8lNmbsZYxpbnAcyUjkSndgvkeTlyeyIyALhSrkbFo/y1c7cAC5HVD3F/CQVbDsM9Zjm8ZNi6eb0fspszw==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-query-operation-source@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-source/-/actor-query-operation-source-4.0.2.tgz#243fcf68ea0fc5b05b602b219edd28207d47ab2f"
-  integrity sha512-TRyBo2qdgl6E21zBAUj7xZgnaM9jHkPE3o5pYPGr77j9ODvb8MZVn0D0UaxNhocq+stOEJsNFkEEPyPhW+1/bw==
+"@comunica/actor-query-operation-nodes@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nodes/-/actor-query-operation-nodes-5.3.0.tgz#0246998ca8657aa07a10622586a0bef7d1657957"
+  integrity sha512-QN4wnv7WDYC8QEyltEliDcqNpVYE2tgrLzW/zyp9DpnUDbwBJt2/29WcrXNfg2riS5UZ6z1EVjBRZ68h4kD3Jw==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-query-operation-union@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-4.0.2.tgz#29fc87ad4506e0952064daa54601385ba81b6212"
-  integrity sha512-rY5QrrzscoI9AEZIBSthaNPdCQp5le4ovPpmJZalFz1Tlg7qsA1Pq5brkOc6RdQnqqfHsIqT7ubOTauQ9/bIwQ==
+"@comunica/actor-query-operation-nop@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-nop/-/actor-query-operation-nop-5.3.0.tgz#f742b62de476544fb7585c6367e1436cba2b6c3a"
+  integrity sha512-nuhkZg3dWHSawedwQjMXzV+Ei6LoEyVuPHl6QvOdWyryJl1jc9onRvjmGqcWgNef4e68O4JDKkC2XcAJ2DyMNA==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-metadata-accumulate" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-query-operation-update-clear@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-4.0.2.tgz#5436b5b6518425644cb8189a7637dbd5758f746f"
-  integrity sha512-j+BrCAWMvAyoMA7SQPv2aFGpwJD5WmtRDEmIxEojFCryydExO0MylbyT6yc7NElJzkJtsVv9RzuAJZQW7Q310w==
-  dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-query-operation-update-compositeupdate@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-4.0.2.tgz#93aaa1f6e6e4875e31f4904275f626ac3bfe2909"
-  integrity sha512-LcgP/QWUqISjCZR4LiARUgBA7AYNkncAYggiN20cGhM7IwAalVrEh/EiKLy6ibxlmtHoW8Zm8Rp8rjFuz1+Kmw==
+"@comunica/actor-query-operation-orderby@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-orderby/-/actor-query-operation-orderby-5.3.0.tgz#e285ac66ec923b711ef8177c40b1d6e4a21e2d9f"
+  integrity sha512-8Ytd/AWtrgG3yui1VI6AlE4dZNy1CSeOygh6aYvTJuGhEotmq0U/2rRvKgXJ0soRFCrjKiqVZH0hB0dOoPqMoQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-expression-evaluator-factory" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-term-comparator-factory" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-query-operation-update-create@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-4.0.2.tgz#16d41cd5758538ab6fdb85a5d07e6f9c1bbbffcb"
-  integrity sha512-U0jZCDZpX0b3cn+OONOjsvQz94AraBZvan41spWWLrTIPHlDKmulydoYmov7nEquHPlzfvblXMCLUNT/9pNgoQ==
+"@comunica/actor-query-operation-path-alt@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-5.3.0.tgz#302178b39988672e87c58059cc879bc7d37ff328"
+  integrity sha512-NgOB1qb+fVQlZyBF1NILvXwEY3cyOSNtFuGthTmbwnsEAbWtNyN6VRTnYLXwQE1MQiJmmIR/WBs9dcFEhCkYbg==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/actor-query-operation-union" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-query-operation-update-deleteinsert@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-4.0.2.tgz#248d954c881b2f156e6178381eead8aa9621649f"
-  integrity sha512-K2P3YWK5idgfxS2GB+piXZk3zLYOgC2p87Dh7AiQrw1mCrpry7XQI9eq+4YnMj2erH2F1nw2gXfTMmyMQAsSug==
+"@comunica/actor-query-operation-path-inv@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-5.3.0.tgz#f6de0b6f07743a054a8115fdce5dc864f4fe04de"
+  integrity sha512-trWKSWwyoOKxfSBqLxQ3q2CVkqDBX6RyZt34AUhtptuLCdCCeV8zzrrtDJOpQbXrZVJ/IAJNGsgype8aIKU3Vg==
   dependencies:
-    "@comunica/actor-query-operation-construct" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+
+"@comunica/actor-query-operation-path-link@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-5.3.0.tgz#3e4537584a511ba84248a2c70a8806f7da956658"
+  integrity sha512-rVioPKxpTx9VtIuwt6Ej9ws+plFtSGcqk/7QcjGt66MyZA1CHuCqdYOgY3CiKRuz74SW76Kp+fNpau/EpFw0cw==
+  dependencies:
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+
+"@comunica/actor-query-operation-path-nps@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-5.3.0.tgz#be8b7c985c018747429f4397de6d4688b2e2ced9"
+  integrity sha512-c1DoFCYUsejZBTR1i3zaLW68FQqVgrrVr0cmBGcApz4iBUTqGWP7Ygl/0Uu88GY/krUSPjuPB6m6Bl/DhXNO/g==
+  dependencies:
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-query-operation-path-one-or-more@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-5.3.0.tgz#01a1ca347c8bad42df220a1dd497dc630eb77858"
+  integrity sha512-JdhnJvRrzroyQMqokRBPWNQ6lSwNjpR5mh8nzvGSvMOxLqua9TXs8ZOksrJZiru1/L97SgNYzlDWm1LVmGmwlw==
+  dependencies:
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
+
+"@comunica/actor-query-operation-path-seq@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-5.3.0.tgz#81c5c75debb425e02bd08502e2206fedb47aefb5"
+  integrity sha512-ERERE7n+BJuw/wwWV8Kc2X2/vFWANLHkP/eGUO2tN+6fHgKsWSzNRRbJokhnjE4ldqNgs3qSZgDA9ioW5qxBcQ==
+  dependencies:
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-query-operation-path-zero-or-more@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-5.3.0.tgz#6d0d715f9d7604efa4a73b23a863f42833fe3aec"
+  integrity sha512-v/F3KwJFDGJhjr6oRmhYED9Ra2XZFa/982nTIIl3uOwP2lw0TDTPHR5hwIG65bv77IY8G/CZ7d8UDJq9jEu9HA==
+  dependencies:
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    asynciterator "^3.10.0"
+
+"@comunica/actor-query-operation-path-zero-or-one@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-5.3.0.tgz#2a764dc6b10689e403f5b45153a1d5e8411f1662"
+  integrity sha512-P8aGi+DL7bqqF2mO4pZewTjxxL90CHRK/iIjwQzx6MHXBYY5+X5uoSrWMDx0GtIZ1kzX1HYZiLFS0SJNg+e29w==
+  dependencies:
+    "@comunica/actor-abstract-path" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
+
+"@comunica/actor-query-operation-project@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-project/-/actor-query-operation-project-5.3.0.tgz#6afdfdf9aa433f24213e579dd6783a9d64963f41"
+  integrity sha512-5JlXX0+iH2dXIFN0mAA8r0iP6i5Sxd3yMNu1nJq2EaMNY+yUDkW0sanjDVqi+3c+vUP4CVaI3uwYjbgEPykf+w==
+  dependencies:
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-data-factory" "^5.0.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
 
-"@comunica/actor-query-operation-update-drop@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-4.0.2.tgz#0f9e67b8e84d47ccd80c10de0b5f600db76d5bf7"
-  integrity sha512-f2AfpXdvnlfFbeh+9FUy1uBSJxh4XdfXKK0HgZbikGVgOVFycv8mXRa1i4wlQWfgNpNT/MFfkB+hKaWAL2CFWw==
+"@comunica/actor-query-operation-reduced-hash@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-5.3.0.tgz#7c6180902deefd3f552aa56aa6656f2cfe015792"
+  integrity sha512-3OLKzcq0aO1Kyjz1qOWJEotiNPae29h2+v0uzTgbDzfsZxxVk0S85zl1AWQSTYs+A79PItKFYPaiDVzsYDiKtQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-hash-bindings" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    lru-cache "^11.2.2"
 
-"@comunica/actor-query-operation-update-load@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-4.0.2.tgz#d3060393cc5fae61aac1d78e11ddf61da1064735"
-  integrity sha512-zau4YG/+gVPkkOGE1+h+GQm/+QTuACeOaBJxRjHpNQcAL+OiXtYI/qbs6pdfV6X0yAcMpLKfJjwFLLm89zCM9g==
+"@comunica/actor-query-operation-slice@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-slice/-/actor-query-operation-slice-5.3.0.tgz#b7b51714394dd5aa24fa888c9063f9bc34270c8c"
+  integrity sha512-A+aNV+wF7KT2f+GEprahjqNd6n2/KQZfbKNoDU/9ZJVEPkl8vT9zZ1ScM7iife/VVTeLybw3KIFJcqOrDveUvQ==
   dependencies:
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/actor-query-operation-values@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-4.0.2.tgz#3fb2071ea9bfb7ee715ca9653641a25cdbd47803"
-  integrity sha512-pc2GB5LbKEEREp2ALlbxO2tOsUNfb9npxjDNep+mkTQuJ+2OWcGWs4kjyKC8Mi6kz6FGFhGPuETe7nK1J634Pg==
+"@comunica/actor-query-operation-source@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-source/-/actor-query-operation-source-5.3.0.tgz#88e23e914c64317fbb736cd13096b2bdb12e4ee4"
+  integrity sha512-YyBseNXKnm5QuueihMeOui0hkNGTS7f4XqxDGxoILi9AgxQZIJI+UAhhLXN4Jt+wcvSyIqGMMhleYkpINemdZQ==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-query-parse-graphql@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-4.0.2.tgz#f7d523dc9435d8aaf712cc9c219612cc17efd9ac"
-  integrity sha512-70QBFexZ/LJ09MBYbBaNdTAVF5cL52hJu1e1ES03Ijq1O/q7pp9AI/9MRGBtr+BpPwVBYxrcT5xr7ibH42m1pA==
+"@comunica/actor-query-operation-union@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-union/-/actor-query-operation-union-5.3.0.tgz#7054d3fb693d47e05e996fd310723e8689922056"
+  integrity sha512-btM/bNbtWh6LIlXgvpTgjFOqNXUfv7kW4izCVBx4uS+e4yb+7rTEi2jNJ9dsF2uXHltRW13m24NR82d/P92TUg==
   dependencies:
-    "@comunica/bus-query-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    graphql-to-sparql "^4.0.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-query-parse-sparql@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-4.0.2.tgz#2855e7f1a39323b8616ef63f2185d173ac9c762d"
-  integrity sha512-7LzxukUNFcixhOeTHNaPdzqPx4t6gRJFpeiVihGihZ/xU9BPPdyAh+XjZD4wAJJIXoC/kn32cTuWw9mxdM6ZPw==
+"@comunica/actor-query-operation-update-clear@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-clear/-/actor-query-operation-update-clear-5.3.0.tgz#f2b1e49e8db3fb51381564e80d6042c3c2c27226"
+  integrity sha512-jfJG+p/1aZWqgvKfw5Wp6jdhQkpJZPD5WbK87RXR6guqxj6YPSeTNSrKtJncp8lUg3y99OPgAYTTNqVdFJPA8w==
   dependencies:
-    "@comunica/bus-query-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@types/sparqljs" "^3.1.3"
-    sparqlalgebrajs "^4.3.8"
-    sparqljs "^3.7.1"
-
-"@comunica/actor-query-process-explain-logical@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-4.0.2.tgz#3c5650ac22cb90bcee577575737d0bd7ee68c6de"
-  integrity sha512-YGRHemxLzgZ7+G7bEqKgpn56dgJZSBsTSXNlaWe51HWkymE6m2kFKmuwjetpCivdWxCSFzN7w1wFYrdWjOExxQ==
-  dependencies:
-    "@comunica/bus-query-process" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-
-"@comunica/actor-query-process-explain-parsed@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-4.0.2.tgz#11f98a5137dd01f7ec5598f87bf9cb1fc531f37c"
-  integrity sha512-mhxzCdFs25n0fRDDledjL8DMinBqhJCPoDB90ySTahvdNI/3riFe7NMov3Igx72V30osUeiYDuVPY4O0ffUGKQ==
-  dependencies:
-    "@comunica/bus-query-process" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-
-"@comunica/actor-query-process-explain-physical@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-4.0.2.tgz#a77012602675ceb049a2e5febfe1170be2261c6a"
-  integrity sha512-LpfodcmUOK4Q8+GVRy6PHytgRrHGqsjt7KRrZ3OFnnkjs5GTbD8xogCvzbvrkdOHzUkzEECL2wdtjarVXGumpA==
-  dependencies:
-    "@comunica/bus-query-process" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-string "^1.6.3"
 
-"@comunica/actor-query-process-sequential@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-4.0.2.tgz#2d6663db35406091990a0fc01a541166e6b1b9fe"
-  integrity sha512-Pr+fTO2TqDW3zrZO1JdrvY5HFxiQ0cmAH242a5WS1lRFwv4wUgsHQDDrMt7JJbGQNcAS3SaB7nXFePfnPgE92Q==
+"@comunica/actor-query-operation-update-compositeupdate@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-compositeupdate/-/actor-query-operation-update-compositeupdate-5.3.0.tgz#79df8cb25603586e95095be1d86c9fd63d64c9f2"
+  integrity sha512-6dfRIzfU65soQ99wBZLyEQ2vapG8wLaM7tIbL6c70zcsmT+FrvR8TyqbwE9J9udl4x7TdhZYFpltvCfkUewZ2Q==
   dependencies:
-    "@comunica/bus-context-preprocess" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-optimize-query-operation" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-query-parse" "^4.0.2"
-    "@comunica/bus-query-process" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-query-operation-update-create@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-create/-/actor-query-operation-update-create-5.3.0.tgz#cfef9204a3dde0ef6e800f7ebff3c42508ba65cf"
+  integrity sha512-sesINoFuaEfUvysskio+E7rD34mSmYEwLhEn/CACrDb9dztdgqej/IatGFQWKZpw6PezDysBVYW5vp5MQS5Bhg==
+  dependencies:
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-query-operation-update-deleteinsert@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-deleteinsert/-/actor-query-operation-update-deleteinsert-5.3.0.tgz#e01a645ce587e64884ab5d40f7431dec963d1063"
+  integrity sha512-yorNuXAvhoWN8A4SmVvqaXREpEadNFPX5gZ97rxPel8auiOnICMCLP1LaRk4mp1RgVRx6b14caQnw8rXMQo1cg==
+  dependencies:
+    "@comunica/actor-query-operation-construct" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-query-result-serialize-json@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-4.0.2.tgz#9524d1f2be1f9850e7caf219928e9e50f3432326"
-  integrity sha512-8l/h10CjvObiyVqP7qE8HFCWTAsLa8y5IH44EfWhf2eT+UJm/yWhEQjEL6S/BFz8egcKBLzmr8H3g3Qxj8K85g==
+"@comunica/actor-query-operation-update-drop@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-drop/-/actor-query-operation-update-drop-5.3.0.tgz#94bd579f5d4e92af3a576928e3122debf341ad09"
+  integrity sha512-FHWlHRHkNTqQWkudlgjXTtZlruwK/kRbZLyMU4kD1XyJMvYeyvJeXUxi+ZYBSJ0DBoZuYnfCupLw97xGcgYkkw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.1"
-    readable-stream "^4.5.2"
-
-"@comunica/actor-query-result-serialize-rdf@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-4.0.2.tgz#6c1b4229273d306395f84718cbe3eca0d40bea18"
-  integrity sha512-bp5TRX3DyEDsgz6GQl0FHarpanh8Qz8tU0KXdkij5+nXHOAeRz0Llt/8I9eHwRo0/s1UtNwxkmsBmwD0QOVN+Q==
-  dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/bus-rdf-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/actor-query-result-serialize-simple@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-4.0.2.tgz#8ca5caa41032c021c5c089d4d09d24016511e445"
-  integrity sha512-I3ilTkwCYbbcCd9juqt9/3g7sk3BAldNxSNGpSNMi1Fw2H26ftt7W88MaZt9+M34NbqoddmUOuY/vOrsZMkNOQ==
-  dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.3"
-    readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-csv@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-4.0.2.tgz#b5ea6bac2ed84926042758b6b93d9f76ca8d41ff"
-  integrity sha512-M5k5q8GPnjzvlXxw8G7kOpO2SeV7zbcMBARW2Mvbyq04oMDOnbval33KwE5tGbcqKWRzIVn+9YEJ11/eTcvkKA==
+"@comunica/actor-query-operation-update-load@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-update-load/-/actor-query-operation-update-load-5.3.0.tgz#718e656f203a5397a7340c3d1db822f38a96b542"
+  integrity sha512-Qi+a6rI56UnSTY7vMJdDwo5x0JRvqBH6W5tNYFjcVSp4pBSJQyt5mgeGECh4nXPOhNSqCSmrwVIoL0YJpytl4w==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+
+"@comunica/actor-query-operation-values@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-operation-values/-/actor-query-operation-values-5.3.0.tgz#a72264ca545512cef8f6774278d687d951a1be0a"
+  integrity sha512-SbUXQvAbGrKH5s/6A2w1JuQDfssrPgJWXAoC3YfdNlEn8CKC2xGrzNmwGma97ldKZwhxZAQaIMPK0kMOKKst+w==
+  dependencies:
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    asynciterator "^3.10.0"
+
+"@comunica/actor-query-parse-graphql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-graphql/-/actor-query-parse-graphql-5.3.0.tgz#69fdb38c61812564f091d1fcd141bdf1b82ff3ef"
+  integrity sha512-hWo9cQkHFrKZVwQDpgdnkzCdvF9JNyLdRNYTTdYD8T+h2tKryvxIfWQu3vCazFH0KW1taZc0krBpvSSmO9a4mQ==
+  dependencies:
+    "@comunica/bus-query-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    graphql-to-sparql "^6.0.0"
+
+"@comunica/actor-query-parse-sparql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-parse-sparql/-/actor-query-parse-sparql-5.3.0.tgz#e31a7abf3aa0ef60934daf17ca403a305b3c0794"
+  integrity sha512-SiSf65f9I3NM4jvzHp8DjfvuLeTLoBemRl54BwdM/VF7LF3XcsqcRrtY/BKIcPNipEt21z6hP6UWrRyywjTrYA==
+  dependencies:
+    "@comunica/bus-query-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@traqula/algebra-sparql-1-2" "^1.1.7"
+    "@traqula/parser-sparql-1-2" "^1.1.6"
+    "@traqula/rules-sparql-1-2" "^1.1.6"
+
+"@comunica/actor-query-process-explain-logical@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-logical/-/actor-query-process-explain-logical-5.3.0.tgz#f8094e3c94567e5e678889b258c26925a70a88dd"
+  integrity sha512-NiSiNJgfburkDNY23QKiNxhnlwNp0RGYe/J06RRhymhaPWv4av7AoZVTvzBpUHIOLbK55G9phPvZEYXJ+COpxw==
+  dependencies:
+    "@comunica/bus-query-process" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-query-process-explain-parsed@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-parsed/-/actor-query-process-explain-parsed-5.3.0.tgz#09e1ecb76e503e4ce32553791e00b622d15b64a7"
+  integrity sha512-OO92YAiJ6dQ1T/x1hOkfNyODLTrE1grPw7L+7aQ2qubOm/OyP3iLmXPa9sjr269WCVUlmthaWbt176WjOKtPrQ==
+  dependencies:
+    "@comunica/bus-query-process" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-query-process-explain-physical@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-physical/-/actor-query-process-explain-physical-5.3.0.tgz#d2387e2789a6f50f5d525d1b2537cef42f0ae7f2"
+  integrity sha512-tFAF5ELPoK7CNHLg1Gtp9VsQmYreH9HqFlvLoie1K9L+2sBAi9It8/VgixVUQYmxjyvJCTFi27nKr7okhGuZrQ==
+  dependencies:
+    "@comunica/bus-query-process" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
-    readable-stream "^4.5.2"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-query-result-serialize-sparql-json@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-4.0.2.tgz#3fb4d2fe441ec1b4d35bf1d76f2f3e48eeec213b"
-  integrity sha512-898M1sODv+6SPAmRKPL72ljf2BrCJ7s/LCFCLqoVUdinkRgmU/VomfBmbUhi+uwVXlZkuUxayUGtjJacOE6r5g==
+"@comunica/actor-query-process-explain-query@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-explain-query/-/actor-query-process-explain-query-5.3.0.tgz#5341c5a3f81b39356c2f7497f66f9d606d70f262"
+  integrity sha512-msLbIIJiSwssWLxQFb9qZJVstkRu3TJAwdz8rDSlEhPNSpAiWJgl7xP0i/8DExifP3Uo8r15IfdYW4A2RfyOBg==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-process" "^5.3.0"
+    "@comunica/bus-query-serialize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-tsv@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-4.0.2.tgz#0c208d36c796d92ea500a6f61fe8f3296a3c7a47"
-  integrity sha512-ZRh2BL8G9kv7hhkjQKaWrC6A8F3klF6ldb7Lhn6Ab/IOomW+ck4HVT1/I9E50G8oDsaBaGq4q85edWvtbIk+Dw==
+"@comunica/actor-query-process-sequential@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-process-sequential/-/actor-query-process-sequential-5.3.0.tgz#65b1c29e6fb705fb4189c8f19e238ea7757d4f56"
+  integrity sha512-e7J6oAfs5OufRdCLY29jv/gNhLkNqWWUrbmJFFfZ6sKKfu1K/Jxqb5OT+jAC4DiMfcB1Z8WMUAKe6ptQkL7WeQ==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-context-preprocess" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-optimize-query-operation" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-query-parse" "^5.3.0"
+    "@comunica/bus-query-process" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-string-ttl "^1.3.2"
-    readable-stream "^4.5.2"
 
-"@comunica/actor-query-result-serialize-sparql-xml@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-4.0.2.tgz#cd3d7f5097f29dc7653cea6bf87e24b27224128a"
-  integrity sha512-j2kReB9u14XjFC/pNkZ2UYShyRSNRjxu3LQcF7qf6iOJOQSSvQ3ps8Vd56oBjeQ23ZIlE4qHK+oyBFYkYhzcPA==
+"@comunica/actor-query-result-serialize-json@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-json/-/actor-query-result-serialize-json-5.3.0.tgz#1db5d29bc94dce7d0c383abc76873b74510d58aa"
+  integrity sha512-HmUajWoV1disxavzN9w+xe1J0DyB/2FiIsS7AfxCL5vErXVf9uP/La131kTQ+j212nGZX0Yzt1YjCuO7+LqDHw==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-result-serialize-rdf@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-rdf/-/actor-query-result-serialize-rdf-5.3.0.tgz#fc7421093fb5e442afa9183ad8128bea219300f5"
+  integrity sha512-kEhuXXAk4a5dC1/01sEPGW+1gy0NrCZlEzUaSM8Fs6kskaBh9vIcnyxIoqiZoiMhGdOI1K/jRNGlC4Dwk75Flg==
+  dependencies:
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/bus-rdf-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/actor-query-result-serialize-simple@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-simple/-/actor-query-result-serialize-simple-5.3.0.tgz#8eb4d8ba9249bd5affc53db6296c30d01c4d0541"
+  integrity sha512-u47y97BbftZyXm3cuZj7mBwJTZYBtM1tb9fi6cgN99typ8s4kZTbWQhNSltcbPnw6N3ftEVNg+P1XddptkFJWg==
+  dependencies:
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    readable-stream "^4.5.2"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
+    readable-stream "^4.7.0"
 
-"@comunica/actor-query-result-serialize-stats@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-4.0.2.tgz#25675ab49f3ddf41f14f90daa23dcaee4aaf787a"
-  integrity sha512-T7slQKZo4c8qG/lVUiot8K7dldrDS6z12YOmcviPrNyEIsSx914ECUQdIpiP5x3j1Ey5XLJc7VF8x5jb1Qx5Aw==
+"@comunica/actor-query-result-serialize-sparql-csv@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-csv/-/actor-query-result-serialize-sparql-csv-5.3.0.tgz#e76faefac00019dce66e0498ffc7595af5ef33bb"
+  integrity sha512-b3F5zY/YuhhIm9LLyALBh7B/4IlYTGUbdNJIgszl8wA92WVsixYmIGF64IzygZcfdg/OeZ3FR/cDQxStFlugIQ==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    asynciterator "^3.9.0"
-    readable-stream "^4.5.2"
-
-"@comunica/actor-query-result-serialize-table@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-4.0.2.tgz#082cadcd7346865b11052964fb97e3cf23dd3057"
-  integrity sha512-0kKVbYe3lyUTk/2Z6m7G3XgTjitbirCqASLB6OQpTflYeJcS85TwhhhVITDuT4TpZygu9iJq8q7N7dma4lkySQ==
-  dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-string "^1.6.3"
-    rdf-terms "^1.11.0"
-    readable-stream "^4.5.2"
+    readable-stream "^4.7.0"
 
-"@comunica/actor-query-result-serialize-tree@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-4.0.2.tgz#37eb23dcb3e31ece121917ae4e289c1bcb7ec682"
-  integrity sha512-yY8udXeygSsQwWRyBT7WaQUCthS7RDStViYO9R6L3YUtahCZNXYg8PbvVrZbN8VwX6cnO2Sf4IlhJET7QStReg==
+"@comunica/actor-query-result-serialize-sparql-json@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-json/-/actor-query-result-serialize-sparql-json-5.3.0.tgz#bbcb76bc89dd07ba3293b53c470153acf85686e0"
+  integrity sha512-/+uUdv0+nvmQOgequNliYi6IGGmARpctZwC0MX1DKirwW1fVwtCCov4Gpj+FKUccYoRQgya6BFkineIV4S7HYA==
   dependencies:
-    "@comunica/bus-query-result-serialize" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    readable-stream "^4.5.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-result-serialize-sparql-tsv@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-tsv/-/actor-query-result-serialize-sparql-tsv-5.3.0.tgz#72b9a4410ddab093b9f9a4bde6f3cd5ca9ed3222"
+  integrity sha512-zah/xsrMAlbQ3gddGLaOjjtweptitPh9JzZSid/ulZttNrdK8NV2752qp2vRrvdwYMhx9k9+P/ifKJ1LNPGvDw==
+  dependencies:
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    rdf-string-ttl "^2.0.1"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-result-serialize-sparql-xml@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-sparql-xml/-/actor-query-result-serialize-sparql-xml-5.3.0.tgz#298e60bde726d8014e8659629722e8fc92074cd6"
+  integrity sha512-+DeLA7dVPhL/ND5/WpyGlvdFJXwCNHzEGlr44Ci3xu7zp5b4dvmbPk+MzXP+LBu8AB6Q+Nf4If/6bBkPCSh5+A==
+  dependencies:
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-result-serialize-stats@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-stats/-/actor-query-result-serialize-stats-5.3.0.tgz#7935b39689e9c01d8096d0519a5966266eb5a4c1"
+  integrity sha512-aF2tkP2YYomRx+1JHLZ6fDhNO4cL1rtGNQfV0BogjQjrZNrtgqlDeBfETlu9xhTliFRITPXUq6BnJmqekvrrGQ==
+  dependencies:
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    asynciterator "^3.10.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-result-serialize-table@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-table/-/actor-query-result-serialize-table-5.3.0.tgz#4713c14fb1d18672cc763898646317e19cff4916"
+  integrity sha512-nOMRkY1x3roDCICFCibeL7z3q2lWRrJ8p0deljW/4qf8CMWLA+1o6OoeF9Fe07KYY2Xa1eXrGpa4dAWVMGVTyg==
+  dependencies:
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    rdf-string "^2.0.1"
+    rdf-terms "^2.0.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-result-serialize-tree@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-result-serialize-tree/-/actor-query-result-serialize-tree-5.3.0.tgz#2342721ce7b41d8fc463ee9e78a6e59211754e82"
+  integrity sha512-R4sawCBx+ABt2NbAp8icqoKUGPYacd2uVzHEikQ29f4MgO+3YNyMKhkbjQxKPHSUo0fDL+iKl8OkSoBxOnv94A==
+  dependencies:
+    "@comunica/bus-query-result-serialize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    readable-stream "^4.7.0"
     sparqljson-to-tree "^3.0.1"
 
-"@comunica/actor-query-source-identify-hypermedia-none@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-none/-/actor-query-source-identify-hypermedia-none-4.0.2.tgz#2acd0e94f770d01147a43d25b006b35172e26d4b"
-  integrity sha512-71CbgYBqwm7uqrBHzAD/PLyDvLav+TPpi9W9Yu5maj2ku+hTao+PHy1mIyiWMdkz2R4Kd/5pmnSbI5ryBgRRaw==
+"@comunica/actor-query-serialize-sparql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-serialize-sparql/-/actor-query-serialize-sparql-5.3.0.tgz#c307949c81acee4cd02a9b1d34bd4aef36ebfe60"
+  integrity sha512-8a0r4dr6sMfLBM38uV3iB4EOfHSky1Pz8X56JWEXKEuKmH9SlHiBPdsR4yzPcxOjT/q/v2QqSBLF4pfCoITiEQ==
   dependencies:
-    "@comunica/actor-query-source-identify-rdfjs" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-source-identify-hypermedia" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    rdf-store-stream "^2.0.0"
+    "@comunica/bus-query-serialize" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@traqula/algebra-sparql-1-2" "^1.1.7"
+    "@traqula/core" "^1.1.4"
+    "@traqula/generator-sparql-1-2" "^1.1.6"
 
-"@comunica/actor-query-source-identify-hypermedia-qpf@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-qpf/-/actor-query-source-identify-hypermedia-qpf-4.0.2.tgz#e21b41dc4a9d901364a460b5d32b298b4821022f"
-  integrity sha512-vu4A82FSNeeJmc7/xHr54TJm4LYK5mBIWoIKqNTIBD7wDW9z9ZqF4VhiOEQr/bk3sP8lZIEFih8NoXlcBUfHMw==
+"@comunica/actor-query-source-dereference-link-force-sparql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-dereference-link-force-sparql/-/actor-query-source-dereference-link-force-sparql-5.3.0.tgz#3661abbdb8969826ae2f2bd649433dee37dcf82f"
+  integrity sha512-gJC+YbdPwnvK/qMcjvikZDjJyF5ALFwBdvuZj0r6Cs9NK763/L4Mu3Bgsih1V7gvdxw7STP8TMKIg57ZwYadRQ==
   dependencies:
-    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^4.0.2"
-    "@comunica/bus-dereference-rdf" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/bus-query-source-identify-hypermedia" "^4.0.2"
-    "@comunica/bus-rdf-metadata" "^4.0.2"
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/bus-query-source-dereference-link" "^5.3.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-source-dereference-link-hypermedia@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-dereference-link-hypermedia/-/actor-query-source-dereference-link-hypermedia-5.3.0.tgz#957f04cf3c2cc55ac2c9c79781560a8e552e583c"
+  integrity sha512-2I4kPVXyV5HfiuakWscbTTHbWREkcU+7xbyQ2xVaC2fxrpvNB5V3mToGfKPGvNl+kxBt6XgFz+juZyMTckPvKA==
+  dependencies:
+    "@comunica/bus-dereference" "^5.3.0"
+    "@comunica/bus-dereference-rdf" "^5.3.0"
+    "@comunica/bus-query-source-dereference-link" "^5.3.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-metadata" "^5.3.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-query-source-identify-compositefile@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-compositefile/-/actor-query-source-identify-compositefile-5.3.0.tgz#89ca105f69754ba09f06121e6459427bdbf2ce02"
+  integrity sha512-zyYMXmtx738m9r7Hx7y8trgrXcKCA2GbY6pOdkqUwvp4NGnsi+0sXZMDUfHIiy9HtlbBJX80I/ghJUPqKtMAaw==
+  dependencies:
+    "@comunica/actor-query-source-identify-rdfjs" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    rdf-stores "^2.2.0"
+
+"@comunica/actor-query-source-identify-hypermedia-none@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-none/-/actor-query-source-identify-hypermedia-none-5.3.0.tgz#ea419295275acd1c42da8b475be29ba463b9b3fd"
+  integrity sha512-+JEE3Fuu2pold0CSSDaSQ76Rzmji54knJzTonx6TNBxiOod9ykmoXpJ1SJuZ3/Iv6fyNrVoCeulDcz8C0xVzHw==
+  dependencies:
+    "@comunica/actor-query-source-identify-rdfjs" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.1"
-    rdf-string-ttl "^1.3.2"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    rdf-stores "^2.2.0"
 
-"@comunica/actor-query-source-identify-hypermedia-sparql@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-4.0.2.tgz#d60a5bc66c06b8e4b9f2b8ca6c65cd4f61032851"
-  integrity sha512-gfw9zsh4rXTae0d8S1r3yb6rTy47raK5BGmB2xk26ZLta2m+PVFBH+t8vk5Ku9CYcEY+t//5e8CRPBME71y5MA==
+"@comunica/actor-query-source-identify-hypermedia-qpf@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-qpf/-/actor-query-source-identify-hypermedia-qpf-5.3.0.tgz#8fb0e7051fa155dc7cbfa1d7b4ac29e694dcef33"
+  integrity sha512-fI7iAjGXD9re27V5ggLgme8bIlGve79bE1d4rQ6RTJQFDH83ZGMeP5a7NLrBmxM9/JyDJte2lBEQwshKYcQTCg==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-source-identify-hypermedia" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^5.3.0"
+    "@comunica/bus-dereference-rdf" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-metadata" "^5.3.0"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    fetch-sparql-endpoint "^5.1.0"
-    lru-cache "^10.0.0"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
+    rdf-string-ttl "^2.0.1"
+    rdf-terms "^2.0.0"
 
-"@comunica/actor-query-source-identify-hypermedia@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-4.0.2.tgz#d977a6e49b12ed8283caabb10c07ba6d51e75353"
-  integrity sha512-52QzEN3laBSAzii9KmEsK8Bvbt42BXIFd0YeaWLWOE8EqA4zUF+AonVrjUSsMsOgC8F7SFFawSpzBUt6r8kfgQ==
+"@comunica/actor-query-source-identify-hypermedia-sparql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia-sparql/-/actor-query-source-identify-hypermedia-sparql-5.3.0.tgz#3500d58453ae0604c995bb6abb12dc9a51e676d3"
+  integrity sha512-LMDpKwB5rMA1ACYehtIhepza+fwKDXPrdMBFiMMVb9qymvHRTRSTRgQKoJgZb1SO3jEaMNNv0s75KaYvC/JbMQ==
   dependencies:
-    "@comunica/actor-query-source-identify-rdfjs" "^4.0.2"
-    "@comunica/bus-dereference-rdf" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/bus-query-source-identify-hypermedia" "^4.0.2"
-    "@comunica/bus-rdf-metadata" "^4.0.2"
-    "@comunica/bus-rdf-metadata-accumulate" "^4.0.2"
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^4.0.2"
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-serialize" "^5.3.0"
+    "@comunica/bus-query-source-identify-hypermedia" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    lru-cache "^10.0.0"
-    rdf-streaming-store "^1.1.4"
-    readable-stream "^4.5.2"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    fetch-sparql-endpoint "^7.1.0"
+    lru-cache "^11.2.2"
+    rdf-terms "^2.0.0"
 
-"@comunica/actor-query-source-identify-rdfjs@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-4.0.2.tgz#d5a5eb1331eccaec4701831d5080feb754d7a331"
-  integrity sha512-EfYWPQNDirClntmIQxOBR0Z71a1sclbO7t7NXe50VdFN7VBHeEOfMIaIv2K86BI52kNvdeXU5FIhFzrdQJmBrw==
+"@comunica/actor-query-source-identify-hypermedia@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-hypermedia/-/actor-query-source-identify-hypermedia-5.3.0.tgz#1c26bef19679c9062af48a0778eb558ceed7d2d9"
+  integrity sha512-GeI86/Knx0I3cEpDaHl57duLHyA7FnoyCbVSijT+/5FfzPkfgY/qnj9udmUv7pQUZq8AOwypvUmoRsXvnZPGNQ==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-source-dereference-link" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^5.3.0"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+    asynciterator "^3.10.0"
+    lru-cache "^11.2.2"
 
-"@comunica/actor-query-source-identify-serialized@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-serialized/-/actor-query-source-identify-serialized-4.0.2.tgz#44e20d844131ea501a38e6651e0714f8377d24f9"
-  integrity sha512-qe2C318FXAdWzJwA8m0amK5FNnDTaRVThnrcxrkPfgxglNOGUyaO+Sn4uJB1zMoYWRR8RQ5rEQTzaBm4CX73UA==
+"@comunica/actor-query-source-identify-rdfjs@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-rdfjs/-/actor-query-source-identify-rdfjs-5.3.0.tgz#c3b0c34156ae7cd2dfcb5dc3ce2287e127cab535"
+  integrity sha512-40YD/5Ole/BjVfsRqaaLaW/kW/NtuMCBKO8rqJXsCmVFDUoaFFOn4TQOE9T710hxRu3cZuadlaTuciPuEKLoUQ==
   dependencies:
-    "@comunica/bus-query-source-identify" "^4.0.2"
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-store-stream "^2.0.0"
-    readable-stream "^4.2.0"
+    asynciterator "^3.10.0"
+    rdf-terms "^2.0.0"
 
-"@comunica/actor-rdf-join-entries-sort-cardinality@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-4.0.2.tgz#70131000d9d439085a77777b61a72e1eaa607178"
-  integrity sha512-EfVruGCBPNbqKfUrpHnhJQ0a8eG+dbKEcsaMYarisgfAqztQnquLT10y0LIdzMHiN5plomlc2j/VLg9lZlythw==
+"@comunica/actor-query-source-identify-serialized@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-query-source-identify-serialized/-/actor-query-source-identify-serialized-5.3.0.tgz#3ce4eaba6d9e42feae27790c6fbb84d52ff05431"
+  integrity sha512-XCVBkWYZ6RaD+EzOliVSsn9gWCrYUK5dEPhL4q/m7GvHexcMeMAj3v7SBDNC2HKT4g4aT7p/r12R2wa8iNp4Pw==
   dependencies:
-    "@comunica/bus-rdf-join-entries-sort" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-query-source-identify" "^5.3.0"
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    rdf-store-stream "^3.0.0"
+    readable-stream "^4.7.0"
 
-"@comunica/actor-rdf-join-inner-hash@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-4.0.2.tgz#ba3a370216238dad13021c088f73bd67da220118"
-  integrity sha512-H6XqAiV1iWmKEGbMCF1wjg6cgaPv7Dy2U/MRDJ/yjBmJinJY22Kk1Kx63EAOjZvv2iWcPI0Vfuqfvs4r1GRXww==
+"@comunica/actor-rdf-join-entries-sort-cardinality@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-cardinality/-/actor-rdf-join-entries-sort-cardinality-5.3.0.tgz#d41488375b9981aa301341533751b142706dc568"
+  integrity sha512-QnPoP58iijCZ5ES+24kPygP7sFaxInjYSiBtFn6RhVESe0lW5r2A7r5jeFGkwlAJuHXkJUOxw3mn0Nyn+z8qQw==
   dependencies:
-    "@comunica/bus-hash-bindings" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-index" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    asynciterator "^3.9.0"
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-rdf-join-entries-sort-selectivity@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-entries-sort-selectivity/-/actor-rdf-join-entries-sort-selectivity-5.3.0.tgz#791e86029ad3e197c25199ef52921fd0960f632e"
+  integrity sha512-AJienaS/Zdpl76KuT6uJ2hm3oF3+z5U843A4wY9j4/iuc/7W62orU2mGLHVG7EuE6ynRrG1jB5tQXZQKH7pEdg==
+  dependencies:
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/bus-rdf-join-selectivity" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/actor-rdf-join-inner-hash@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-hash/-/actor-rdf-join-inner-hash-5.3.0.tgz#4afd290109a7806afa2862208f9a9944042d0303"
+  integrity sha512-KGxul6J+cezhVkM73ivPaQyha8+1ghpN3kPbExN2K1/iUjU0Ew2Prh0DYdnhLaRTrHsd/rhtzcIPgE0Xx2bXZg==
+  dependencies:
+    "@comunica/bus-hash-bindings" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-bindings-index" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    asynciterator "^3.10.0"
     asyncjoin "^1.2.4"
-    rdf-string "^1.6.3"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-rdf-join-inner-multi-bind-source@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-4.0.2.tgz#da40da33fd549254832b77c21584f0254a343e8f"
-  integrity sha512-r7PxKoRehK7urJa66SAJ2u9EqsywO4Z1Darm0LihZlzjLX8zZPx24TnAsIPvOfCxn5ISXlSHDrNOUu6PQWjF6w==
+"@comunica/actor-rdf-join-inner-multi-bind-source@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind-source/-/actor-rdf-join-inner-multi-bind-source-5.3.0.tgz#52754b0ed52915aa5c0818776b8cd7f185d8d8bb"
+  integrity sha512-Kt7G31sbSdj5vexXAHnbtbW47idiZ/vbjWIm4SuUsvYCOm2jKpag2UeyFC0A+T1TPKFb32g5vt/OM0Snn616KQ==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/bus-rdf-join-entries-sort" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-rdf-join-inner-multi-bind@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-4.0.2.tgz#a5a59bef0a03ed27e856bc49dff9503e260ffe4b"
-  integrity sha512-YGuTQTm62+ZYhW1yseNlfxtk5L2eeta1J1miu0TA36W5luZZ25j4Wo6xC6m2gWfJBnV/eHxHazd5sEvHAzJPEA==
+"@comunica/actor-rdf-join-inner-multi-bind@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-bind/-/actor-rdf-join-inner-multi-bind-5.3.0.tgz#049f4b3414f1229f15e3759d2f926f9abe211a99"
+  integrity sha512-rmvWZEG8F4WKPqpiRMKYvMwA6wA10WkeZwhYoS5cUKl42ywemvNDExLA6JgtJ6Ib9smlZcyZWWQYav+5l09gHA==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/bus-rdf-join-entries-sort" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-rdf-join-inner-multi-empty@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-4.0.2.tgz#03c5467b4eb2042b6b263589da1693ae519a01d5"
-  integrity sha512-lKBgcps21duI41XnrA+85dcoV9F83RO+0/lS1721jQv+IhOnfVHh50VoZRFUkWb9ng+CRqpKI+RXfkoSAs9DcA==
+"@comunica/actor-rdf-join-inner-multi-empty@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-empty/-/actor-rdf-join-inner-multi-empty-5.3.0.tgz#6703b1d78e79b648e6e2d8a2ac1b3c5ccd066920"
+  integrity sha512-h7W1/cZOb87f/vd7BowSWsvmW6r1CiBbkbSU9/R+PIn4oTIOiHQG+i6IaYee/6is7SLhnziVC5Kr4TgP5/C/CQ==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-4.0.2.tgz#746ce93ee578831223e8bbdf9820fc97f214677f"
-  integrity sha512-eswOK0SO6/DKrhnJx6Oz7wD7UyuJOOxUHZEikq8KEl4nM5ZxhgUQID3T2jUQQD5uAG4yCvqgKHZ+nFkxR3CWsA==
+"@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings/-/actor-rdf-join-inner-multi-smallest-filter-bindings-5.3.0.tgz#61990d34f8083fef94803b75e17783f3ab16a8cf"
+  integrity sha512-LbFKEI6Fr0bqxm15esb+BbM2nYs6OKhf/2893wKoIoUEqWm4laGtZfsZaqFEE97ePPAYih5PoUyufSHrnpUUag==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/bus-rdf-join-entries-sort" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-query-operation" "^4.0.2"
-    asynciterator "^3.9.0"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-rdf-join-inner-multi-smallest@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-4.0.2.tgz#1ad46c958d100141771e8676c6a6d4f40b9ec7ad"
-  integrity sha512-PvoXqbYeHoINrci0zdKZ7dBi5Vzh7H+V0yZ1Jahqu52wPUnk8WcdiKtEQtGiCzMJWwhZNROctJZqMCNzfL/ydQ==
+"@comunica/actor-rdf-join-inner-multi-smallest@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-multi-smallest/-/actor-rdf-join-inner-multi-smallest-5.3.0.tgz#5d6e222c9cc1baa9cf177738bcb4550b7b1cc736"
+  integrity sha512-oLm0sYvlD6l80WwkDpqiieUbd2zOoR/QIdl7utcf9V/ZIdmoNubtoIhezWfcAwpcvTJ6YyIL0srX93dQ9mjiYA==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/bus-rdf-join-entries-sort" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-rdf-join-inner-nestedloop@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-4.0.2.tgz#8c33d975fc37756ba4365e33390d7acb38ec6ff9"
-  integrity sha512-uDZqXOQzilxbdULT1mMD8x/UC8LVNwxxLMp/SgGvrpraJUy/qto/HL5yW6x2T2GL8AELf7uYmr8GBve6CRBCPg==
+"@comunica/actor-rdf-join-inner-nestedloop@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-nestedloop/-/actor-rdf-join-inner-nestedloop-5.3.0.tgz#ed4061084f92e84d934a46cdf8087c07964a1aa7"
+  integrity sha512-/PrAyVVFrKxWMVu/SMXIpJzBo10W4rQCQI0adWi2b8/NV01CSjf9Lbo4Ikxkn17giZJHid8ni7bS1hRE3c14MQ==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    asyncjoin "^1.2.4"
-
-"@comunica/actor-rdf-join-inner-none@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-4.0.2.tgz#1bbd40ac03e8a1c7d7011474fc948bffcb2860dd"
-  integrity sha512-FFT7jyD+qzsz0wUENNZuuTfgq1N1i0mmafWKJ2XPsOS1E6UEshC48PQBZbwYm0u8k4jTbDNKoPWz5XvEi97/Iw==
-  dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-
-"@comunica/actor-rdf-join-inner-single@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-4.0.2.tgz#d937ce8b8e1f22b6fe3931aafe79d11d446c6d35"
-  integrity sha512-KcA2mW+wn3MU1kSSkQvRQEqp0DhImvSI88lq9KIgYrQltVYtRKr0a4gfWspgHbuM3JbRU8EmIL6OUOyZF1BCAQ==
-  dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-
-"@comunica/actor-rdf-join-inner-symmetrichash@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-4.0.2.tgz#819d596315426af3ef9e72b236822962a64fac7c"
-  integrity sha512-sv+kIxOXlPdrmajHBKs29MwiJetyhKeMlH5wdwaH/D7DzLSy6Cd7ZGbbKbxfeJ6bGbK8iGnTYOivQ3hPaqr97w==
-  dependencies:
-    "@comunica/bus-hash-bindings" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    asyncjoin "^1.2.4"
-
-"@comunica/actor-rdf-join-minus-hash@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-4.0.2.tgz#7aa9c11c5271bdd364a6d9ac36ce3f41803af576"
-  integrity sha512-nsXXG5XUQyYUn+YxLARWkSH2dUqFVZonsJZ7WTe7DiPVM8/s9rhPAT9iAhxJBlO0ANUPuLvrfdSC07XeVA/Zuw==
-  dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-bindings-index" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@rdfjs/types" "*"
-    rdf-string "^1.6.3"
-
-"@comunica/actor-rdf-join-optional-bind@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-4.0.2.tgz#c24318b762b42187bea198cf23722901fb8824d4"
-  integrity sha512-8OM7+EdJmTsocywCpZBEZIX4qkclnkAuHpLLZgfXjnWqnNEQfP+8fdbNzxDTDj+5mPTWHNTuxZemliXAiYsQQA==
-  dependencies:
-    "@comunica/actor-rdf-join-inner-multi-bind" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-query-operation" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/actor-rdf-join-optional-hash@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-4.0.2.tgz#3601595e17b95d67890229990da47aa7359c6b7d"
-  integrity sha512-Exid4OEsAQMyc3OIGMjLfHGYU9Fvd89tlfJpqmrz/lZCT3vVDVDoBXcPynXR3eu3UCJ4+IrGPeyL1dXBBy15Bw==
-  dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-bindings-index" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.3"
-
-"@comunica/actor-rdf-join-optional-nestedloop@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-4.0.2.tgz#64e7252d451cdeaa1477f9161babec766fcff150"
-  integrity sha512-W5lBkNALgLpfQdFwn/ivI75IXrlOyCM5V1HXE/3kBFjAgMxhQtza4Fielgu4oDxKY1MYVKAGhUAatkl5VRCw5A==
-  dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
     asyncjoin "^1.2.4"
 
-"@comunica/actor-rdf-join-selectivity-variable-counting@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-4.0.2.tgz#2c1204013e93c18b13e586db9cd27bec4bfdf4be"
-  integrity sha512-9WlIdONQYy/HWkNF2Jp0pf7DaOY8CLCPXayV5C7/TObedsHdepl7c6S8GnS8unMttuYWPhijxSMrRN9w8oL6tw==
+"@comunica/actor-rdf-join-inner-none@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-none/-/actor-rdf-join-inner-none-5.3.0.tgz#13d6659d5a9cb9a38952dee380049e750f3d04a9"
+  integrity sha512-uRbdlP4OjkcvIiAenU2Jxo2Sw1uOBo0QoGO/UcmJfFCMQWbvzFliVICJfgjwPazrpfZLtIBQ/8xpkTbzn7GjgQ==
   dependencies:
-    "@comunica/bus-rdf-join-selectivity" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-accuracy" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-rdf-metadata-accumulate-cardinality@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-4.0.2.tgz#f1e2eedb7a80845db9b3a6a31bb427633cc1f4e7"
-  integrity sha512-sXP1ZenwQ/EIRVmBurn+yLm95KsoGKP1oOQ0yNn803OvCByfsE77P/coaH/iL5Ijyqbiq3aulk1bKcZ4UKZ76A==
+"@comunica/actor-rdf-join-inner-single@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-single/-/actor-rdf-join-inner-single-5.3.0.tgz#e6dbb7c87007668bede754506085f0044efb1c5e"
+  integrity sha512-XTQXtQgTbjxMqwaXonWt0AdXHHQ49dDNeG5VUNdGsEYrY4uHio8m1zAfWV8ZBCwf8x371v2sXWl4Sz3rL5zNoQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-accumulate" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-accumulate-pagesize@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-4.0.2.tgz#66ce307bec0503eed6e9aec8fee24c5c4a26f013"
-  integrity sha512-FAdeIYw0PFcsuy/6u8bd0IQtQlzsFiYDVe31AzUi8IrC1FlCBYKsLLqWZ5kpCpZ1f9xKak+EIeBv1dXeBrQgZQ==
+"@comunica/actor-rdf-join-inner-symmetrichash@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-inner-symmetrichash/-/actor-rdf-join-inner-symmetrichash-5.3.0.tgz#cdc3582e179d289812b34da2c1f0714b477b7358"
+  integrity sha512-r09fO1Fwg6P9rud0Gv/vmt39KD8hmXT17zYlKn0mkg1cLhtmSFVNra1tW0PdQzdpYWXWNDxyAojerDW1HjZ8dQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-accumulate" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-hash-bindings" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    asyncjoin "^1.2.4"
 
-"@comunica/actor-rdf-metadata-accumulate-requesttime@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-4.0.2.tgz#96141c86d6c1bfdf5d6df6c3c5c31243d461ee01"
-  integrity sha512-jCZUe0vr/JHH+aCM2K3yviXLGLvYJ2r+EAB1UWBYNS+AJziDaNsW9MocxYEgiFKOZrKOnxjoOOA9l32gUoJ39w==
+"@comunica/actor-rdf-join-minus-hash@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-minus-hash/-/actor-rdf-join-minus-hash-5.3.0.tgz#7bbed4549307173c5b29485779b4f82a63692598"
+  integrity sha512-836AXeggHS1NZ7/cE5jRpT4DGeBPzKnkOakJzzLzExeHp6+d33Qsa3okB9LrkJoptEgL7QGaoUreyfhOhJO1uA==
   dependencies:
-    "@comunica/bus-rdf-metadata-accumulate" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-bindings-index" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    "@rdfjs/types" "*"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-rdf-metadata-all@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-4.0.2.tgz#d4b084540894401b825408cefd33c387c0500602"
-  integrity sha512-bkPCKPIbUclY5N33jwcBILOvvL+nIJewgoTkfrivhhqFpn0gA0EUfHYyZ22M7516xKwjA0mBTW4E3kkaAekGVA==
+"@comunica/actor-rdf-join-optional-bind@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-bind/-/actor-rdf-join-optional-bind-5.3.0.tgz#2ba8ae56ce199f36539f552072757252808cf36b"
+  integrity sha512-G+1CySU4KRuN16YTOENfEuE7Ba/CbIBDBXX9dpPUMDWTlxJQ787oHmK9keop6mtAgIvh1J8ukhpcAxG2QNPPrw==
   dependencies:
-    "@comunica/bus-rdf-metadata" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    readable-stream "^4.5.2"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-extract-allow-http-methods@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-4.0.2.tgz#5f9b2e3c45689c1dd0ad988f4825222c0fdc6cf4"
-  integrity sha512-viW5USUKJDk8/YeuiaaPdcwfIQaju7A1hNUVeNsOtuFZQu4khkxIwH8RYi1U7NMVe2Ou0VCBRlaPMM9Bdn0yKA==
+"@comunica/actor-rdf-join-optional-hash@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-hash/-/actor-rdf-join-optional-hash-5.3.0.tgz#be8556d90e9d7688742de858be7b4c8b99610dbd"
+  integrity sha512-EExbPqR+N9ux07lewB9FJHACCINpz+b0hBw4fZDObjB3C7MzHUAlV3iJrEbiRQI8KtHGE0A2Dz1xcYWV66p0fw==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-bindings-index" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-rdf-metadata-extract-hydra-controls@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-4.0.2.tgz#57c646b5299445bc496682711fa7128a782d8bb0"
-  integrity sha512-C/uIofSnO4dPWqhWcY8jLwMc4AviZtpc+p1nCqUMmo01flt0xYex0ZMq4+OzdgSj28n54lYJ/7knjtYWeZV2lw==
+"@comunica/actor-rdf-join-optional-nestedloop@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-optional-nestedloop/-/actor-rdf-join-optional-nestedloop-5.3.0.tgz#4ad4ed002a7e5636e859f08afd1532665b87407b"
+  integrity sha512-vsYkMqBbvoAgUBjgGQB4BxtO09l0T178OGqO33Np0RXEo3vuAkL+jjIUD4wL10Zr9F8XZ6OEAmrhT/di9FMqww==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    asyncjoin "^1.2.4"
+
+"@comunica/actor-rdf-join-selectivity-variable-counting@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-join-selectivity-variable-counting/-/actor-rdf-join-selectivity-variable-counting-5.3.0.tgz#c940348c9b8e817853a3cbda1f24a5922dd6abb3"
+  integrity sha512-1VG2rIYdE+zVpG3T3QtACffrFBFR3tDdXZNCnwMur+HTvDlBZB7ni4tRGl1ENnGnXw8JUKdJoJTPX0a7YiGYnQ==
+  dependencies:
+    "@comunica/bus-rdf-join-selectivity" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-accuracy" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-accumulate-cardinality@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-cardinality/-/actor-rdf-metadata-accumulate-cardinality-5.3.0.tgz#41924daef113c4e5adbcc016e55f2b905d4443fa"
+  integrity sha512-vDNJOHoRO7Lhk+dmIT9ZWiUBjDBi5hbOJDMke0akZP5mc2rooVckKyWDlofxqyk6bI4bDGDfQs8T9LnFw9v9xg==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-accumulate-pagesize@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-pagesize/-/actor-rdf-metadata-accumulate-pagesize-5.3.0.tgz#f30c6c22ece36bef56309af27d2ea52a2b0e8c33"
+  integrity sha512-93ibAxT9DTXNWMsOB9NGCmBaDNMNnGHXW+n8BsqNnUeqX9SY1C96wxD34u8nNvfb8BAtwEopzsMqCA3a+9HCfA==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-accumulate-requesttime@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-accumulate-requesttime/-/actor-rdf-metadata-accumulate-requesttime-5.3.0.tgz#ae5f2bec9a8579c7f6f94e907f8707c638c5b232"
+  integrity sha512-TJ3mj+Y1l2CgfekoPdbx2w9yIbAwPam9mWL/YLaNkYkYEfQkcgAq+SN3eLPbIklRmjzcfkaXmE57QR1NZgTlng==
+  dependencies:
+    "@comunica/bus-rdf-metadata-accumulate" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-all@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-all/-/actor-rdf-metadata-all-5.3.0.tgz#311aa45a29e5cad35dffa702780d76373496b1fe"
+  integrity sha512-vI+Yj3cH3clSL6ClCu5Lat5JlkOQnz0oeLXRjTAGLNNoZlxBLuSq4+939SKe4EC84RlljITMHXQEZ5CEiQjO1w==
+  dependencies:
+    "@comunica/bus-rdf-metadata" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    readable-stream "^4.7.0"
+
+"@comunica/actor-rdf-metadata-extract-allow-http-methods@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-allow-http-methods/-/actor-rdf-metadata-extract-allow-http-methods-5.3.0.tgz#430e6cab5d179e71dcdbfbf70ce230284f249d92"
+  integrity sha512-VuJOyFfFXz9vENWHJdMr7VwfL6JRxiE7AbOjrtqc009aHTfWpShA7oZEmrTw9CVL7pAT3e4qwLcwr5CkcXWJ9w==
+  dependencies:
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-extract-hydra-controls@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-controls/-/actor-rdf-metadata-extract-hydra-controls-5.3.0.tgz#5ad78374f161f648e41f7444eb288289786da790"
+  integrity sha512-RjRFgfECoj0/GW0mq1bgoxS4qHtdfxwAXQt3kU58Nyh3O89MqO+bmdNEE0wycKg3+Lb6CJ2MjR778+EVJd65Bg==
+  dependencies:
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
     "@types/uritemplate" "^0.3.4"
     uritemplate "0.3.4"
 
-"@comunica/actor-rdf-metadata-extract-hydra-count@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-4.0.2.tgz#38d5c08879d5837858b2787806ae5409cf310feb"
-  integrity sha512-k8/WxoOxEj0s/vpSXCj4CkcSrz6G9dLbgo+pj10Rw5x0fbMkrh+h4aLdHIS/D4w3zseDuQf7/5ZQ65FwF2oMzw==
+"@comunica/actor-rdf-metadata-extract-hydra-count@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-count/-/actor-rdf-metadata-extract-hydra-count-5.3.0.tgz#ac91c47664033f47ceb9f80dc46f5c6cfebe3a22"
+  integrity sha512-fmux4a+ZGtYCBNS1clFgd4zKy+hmU3DyEGkZJN1jyrM2x1PZuMaduNcMaMjIqHCIqDtUHa4wjo5UTxuPpIbXOA==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-extract-hydra-pagesize@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-4.0.2.tgz#76f0b08236eee795363d6020c4c5b3d9fd505b11"
-  integrity sha512-UzSsdrbjkDJSkkPQwA0CUT4wvRz6aoXsMU96eiQ9GF60UoUAlOocSxjh9cJEIex7krXj2nPeJRpygHQ5yuL7pw==
+"@comunica/actor-rdf-metadata-extract-hydra-pagesize@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-hydra-pagesize/-/actor-rdf-metadata-extract-hydra-pagesize-5.3.0.tgz#16f63da0039f98534d6bd8fb3f9284a90e26543b"
+  integrity sha512-LOIleGhrcHKCgJ6lnj4LWLhA757RLHylEGKQ+fK2VdOIxFxPcfHfLWw5Oof/C9P5BXMF3HFn/wF1W/RLRh6F8w==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-extract-patch-sparql-update@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-4.0.2.tgz#2bdcfc9a4913c005140c746b69104109c6bdb505"
-  integrity sha512-znMkFKA+X2tovMwe9joLGngUpLpM52lB5FUWLzk6cGNjdUc/iu2QukZ4S7tHPCYwv9mSir/tWIVxmv5Fa5Wy5Q==
+"@comunica/actor-rdf-metadata-extract-patch-sparql-update@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-patch-sparql-update/-/actor-rdf-metadata-extract-patch-sparql-update-5.3.0.tgz#95f9ece954751b45928634620d1b4cb2ee1f3117"
+  integrity sha512-fgemwiEno13bdtAjlhbByvy8OCwQ0doTW+Gq34SBERacEvbOLCKoSWoSxkgqKTI9g3hFoE8zI5N2YbDmFLxqsQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-extract-put-accepted@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-4.0.2.tgz#d3a05eac2953ba1eaf85a9cf980a4dd2b212481b"
-  integrity sha512-10RobQoYPTqNCJ1/Uhu9TyC5+xmDVTC6ROez4TJatWlXdv/LRV7omsqfXPPbAzOgWqKP2NKdV0pk1jD+lRlwaQ==
+"@comunica/actor-rdf-metadata-extract-post-accepted@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-post-accepted/-/actor-rdf-metadata-extract-post-accepted-5.3.0.tgz#3b1d1fbcfa08100c33c1032a698dbae22ac069ba"
+  integrity sha512-4M7sHIx38br50YhVFN3JTWcbd1F6StenePeiQu61Hg69s9Kmb4W8CuLn0hkf2yQnL/KueMOpcse2Rj0kb5jVMQ==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-extract-request-time@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-4.0.2.tgz#567c3148354a58d600a002aed1486b5504a06caf"
-  integrity sha512-wFWgK0dJPiSv59hCsEozUXyBk40dnMlZq/s7uicPS3qFgmM67WunzfrJXO+pAWELPtkdCs2jdsXVAhBd11biyA==
+"@comunica/actor-rdf-metadata-extract-put-accepted@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-put-accepted/-/actor-rdf-metadata-extract-put-accepted-5.3.0.tgz#72c8c9852e2bb12f6ec4bfcf3d64025601d0d647"
+  integrity sha512-i9wLmagoEZXW/cOPBnh5das+Ui3HwhXTbNTOxUqJn8yhUn0zUmsx5ZQee7BM4TXcTfaSO7rBlO62IdALVFPC6w==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-rdf-metadata-extract-sparql-service@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-4.0.2.tgz#a7a5e1e9ec6cec521857d1bc3f2d7e91af647fb8"
-  integrity sha512-/y+1JKBKO6L+FXlO4cD1hJbjjpdNqGMriC7lsMphj6G5ONPEjYDLYSkcHsfi1Vf4FCtSCvMnVeDKT5pGzmz0Iw==
+"@comunica/actor-rdf-metadata-extract-request-time@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-request-time/-/actor-rdf-metadata-extract-request-time-5.3.0.tgz#49764d35d8e499f9366d633ac98cd846c76dccc8"
+  integrity sha512-FKwg4rn27LjIigCVYKfFvJisQCORzFRQXTXpjoy46IibSXqYkQ5SIGELNcmts067m6juaK2f5quf4GO9Dm4kjA==
   dependencies:
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-extract-server-software@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-server-software/-/actor-rdf-metadata-extract-server-software-5.3.0.tgz#3a84cb6f2a0a93f9f37f658e0515938c52080e8d"
+  integrity sha512-3H/+oElxGmuGBfgA4cGEDgUSNw8ULxLI5lXr8UcmnXTo6UUBu6aQUMrhhT5Qcm6ZqgfK3t2AhzV5tanIyVR7nw==
+  dependencies:
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/actor-rdf-metadata-extract-sparql-service@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-sparql-service/-/actor-rdf-metadata-extract-sparql-service-5.3.0.tgz#3e0a710ef787430c2a413610c7e63ab7298950f7"
+  integrity sha512-+jM4HTQlCXy8AhLpU0qSETqU9/HjNo6MnLYod01mT68By5pmajgrH+AtKEsA7GJK1oD9cLjmuLFzAebb7fHr6A==
+  dependencies:
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@rdfjs/types" "*"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-metadata-primary-topic@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-4.0.2.tgz#b5d76f630794198b79d22345a2108e9fa459630e"
-  integrity sha512-0+856iChAuThkC63G/PBnDVKpZso9OQzCGN6HVEHcnlICAR3/SVXrlkG6k2e7Oes0tSB8ky/opZamMZ9JnRBzA==
+"@comunica/actor-rdf-metadata-extract-void@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-extract-void/-/actor-rdf-metadata-extract-void-5.3.0.tgz#a892eefcf1b48429410e6b1d2ebf0358ea189285"
+  integrity sha512-y+98VZ1xeUmpisEf4/XtKu7aTlx0MthEeeFE4GxUKcHMEoXxk6ZbBHs0CorQ/DTYQulKEWb2WJoUuTBiunPsCg==
   dependencies:
-    "@comunica/bus-rdf-metadata" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
-    readable-stream "^4.5.2"
+
+"@comunica/actor-rdf-metadata-primary-topic@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-metadata-primary-topic/-/actor-rdf-metadata-primary-topic-5.3.0.tgz#631435abe924cc71f2744d56f7ab1f9f6a42eaad"
+  integrity sha512-UJGJiooH4GYAK1WmTHoKC+luOD/x8rF7xtU9GDT1GnOH+laWufb3qNmrcRkB+LJ1skZwaE8jj3+JQntZ+xpAZw==
+  dependencies:
+    "@comunica/bus-rdf-metadata" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@rdfjs/types" "*"
+    readable-stream "^4.7.0"
 
 "@comunica/actor-rdf-parse-html-microdata@^2.0.1":
   version "2.10.0"
@@ -2822,7 +3052,7 @@
     "@comunica/core" "^2.10.0"
     microdata-rdf-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-microdata@^4.0.1", "@comunica/actor-rdf-parse-html-microdata@^4.0.2":
+"@comunica/actor-rdf-parse-html-microdata@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-4.0.2.tgz#b137f5dcfceca891f0726a93140eae02625d7843"
   integrity sha512-avW0OuD9kCQXwI19vnfZIUVh7PEhs1g90XXHRohwT9lz5hbU4uGZFrUw3owPsV5CwpTBxLMFijBPrk6foN7fog==
@@ -2833,6 +3063,17 @@
     "@comunica/types" "^4.0.2"
     microdata-rdf-streaming-parser "^2.0.1"
 
+"@comunica/actor-rdf-parse-html-microdata@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.3.0.tgz#3268d6fe79d9044926a8af74aac66083342122aa"
+  integrity sha512-NsKekH1HkWSTDTCJv+ggAvtqA3495FNCquNunfm53uMm86e16JlQBnF50tWMHID/2I3etAh6d+USKNMCGKj1BQ==
+  dependencies:
+    "@comunica/bus-rdf-parse-html" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    microdata-rdf-streaming-parser "^3.0.0"
+
 "@comunica/actor-rdf-parse-html-rdfa@^2.0.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-2.10.0.tgz#21ee3aec806a085db93e8f216647dfc0fede480e"
@@ -2842,7 +3083,7 @@
     "@comunica/core" "^2.10.0"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-rdfa@^4.0.1", "@comunica/actor-rdf-parse-html-rdfa@^4.0.2":
+"@comunica/actor-rdf-parse-html-rdfa@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-4.0.2.tgz#0e3fa258ec77a2c1f68ac94a00663954881ee895"
   integrity sha512-OkcV5aJaCLBzNo5/C/MsJvYBCCRFF2WrQyqmoT+w1/vkM4YKYZ7aL87uDKBmB2bTPDUJ6kfLxTV1miQDMI+JuQ==
@@ -2852,6 +3093,17 @@
     "@comunica/core" "^4.0.2"
     "@comunica/types" "^4.0.2"
     rdfa-streaming-parser "^2.0.1"
+
+"@comunica/actor-rdf-parse-html-rdfa@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.3.0.tgz#997eaa0aac72b4c1c02c51c7f3b46f425468822b"
+  integrity sha512-lVHir3Pb5Xu+mIwX47lGDf0zedJV+eeUJfdhAJlwpso4ycbZ45B4ZEF5Oq4NsHgcADGi7NmJN1bYP7SJwazP4w==
+  dependencies:
+    "@comunica/bus-rdf-parse-html" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    rdfa-streaming-parser "^3.0.2"
 
 "@comunica/actor-rdf-parse-html-script@^2.0.1":
   version "2.10.0"
@@ -2867,7 +3119,7 @@
     readable-stream "^4.4.2"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-parse-html-script@^4.0.1", "@comunica/actor-rdf-parse-html-script@^4.0.2":
+"@comunica/actor-rdf-parse-html-script@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-4.0.2.tgz#0465c245d7da8d8c6328569406b75f9496f711a7"
   integrity sha512-oGB52p+ug1YesdnKoonzQxI+yoLKr2j8ds76vdyMw7bJVVl+wSgXzqmwGan2TDmu26WZ/uGK4jQFshtlCiS8RQ==
@@ -2879,6 +3131,20 @@
     "@comunica/types" "^4.0.2"
     "@rdfjs/types" "*"
     readable-stream "^4.5.2"
+    relative-to-absolute-iri "^1.0.7"
+
+"@comunica/actor-rdf-parse-html-script@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.3.0.tgz#59280443a736d97da010b92b177bbaf432e41691"
+  integrity sha512-g1pYe5KKhWA3gROxt3J1wIfC1imnm445FP40phxtt8zKdF1s9f8O0aBr6p8zAybiZ3KgBaKRT+OCCbzSQoiapg==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/bus-rdf-parse-html" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    readable-stream "^4.7.0"
     relative-to-absolute-iri "^1.0.7"
 
 "@comunica/actor-rdf-parse-html@^2.0.1":
@@ -2894,7 +3160,7 @@
     htmlparser2 "^9.0.0"
     readable-stream "^4.4.2"
 
-"@comunica/actor-rdf-parse-html@^4.0.1", "@comunica/actor-rdf-parse-html@^4.0.2":
+"@comunica/actor-rdf-parse-html@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-4.0.2.tgz#4330c864a07a9c2841139d4b4cd391bf952f2a9b"
   integrity sha512-I10FGPMmwuwUBUi/DZJmAKXqdqb5Ue/oJ8JFifozHdmMZYVcbYCa4AvMQIAKi3qrLeQXciMl7GdA0eb4FQ5/Ag==
@@ -2906,6 +3172,19 @@
     "@rdfjs/types" "*"
     htmlparser2 "^9.0.0"
     readable-stream "^4.5.2"
+
+"@comunica/actor-rdf-parse-html@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.3.0.tgz#3ec0dc1f26204ce42cd2f055fdda346e2143f88d"
+  integrity sha512-QM6AobgQ2Gq3ndSa9B20EH3nVribY8LpqEDJfiDwmXBrZpx7p95R0nxlllVZx4beIisZrKSF9FyN00xrhiDQ6g==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/bus-rdf-parse-html" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    htmlparser2 "^10.0.0"
+    readable-stream "^4.7.0"
 
 "@comunica/actor-rdf-parse-jsonld@^2.0.1":
   version "2.10.2"
@@ -2921,7 +3200,7 @@
     jsonld-streaming-parser "^3.0.1"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-jsonld@^4.0.1", "@comunica/actor-rdf-parse-jsonld@^4.0.2":
+"@comunica/actor-rdf-parse-jsonld@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-4.0.2.tgz#ecec4d9c1b79c9823a7ca5c47d7836b2c12172fc"
   integrity sha512-CpfMvwKOmKf171jlhgztM1WeYDx+VGgODUD1Nq57WkjBPKniHlES6RT5J/4hiPuB8bEyiuX0D65dQLtk32OhAA==
@@ -2935,6 +3214,22 @@
     jsonld-context-parser "^2.2.2"
     jsonld-streaming-parser "^4.0.1"
 
+"@comunica/actor-rdf-parse-jsonld@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.3.0.tgz#3b0ad1d145d3cb907b6d04f8b979634cf34517a2"
+  integrity sha512-bSc8E5nN3H/DnZAi/8AljAbmyv0XuKiQe7tObDKpemhBIKJO1Ch8h/45+Y3ud4NvqJBgu/OEVC4bQL38MnsuBA==
+  dependencies:
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@jeswr/stream-to-string" "^2.0.0"
+    jsonld-context-parser "^2.2.2"
+    jsonld-streaming-parser "^5.0.0"
+    lru-cache "^11.2.2"
+
 "@comunica/actor-rdf-parse-n3@^2.0.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-2.10.0.tgz#94b28690d4a06f8944dc62930adc3346d2d61f0c"
@@ -2944,7 +3239,7 @@
     "@comunica/types" "^2.10.0"
     n3 "^1.17.0"
 
-"@comunica/actor-rdf-parse-n3@^4.0.1", "@comunica/actor-rdf-parse-n3@^4.0.2":
+"@comunica/actor-rdf-parse-n3@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-4.0.2.tgz#21eaf8fbb4eec1047b3f9bd5e5e1aacb9db671db"
   integrity sha512-9jLntJGaXxUf//qC4J3svwjI7nDpyycIkpAwVCilqKpPhqo+Slji/8hfVQd5YPfuL30jgxqNHAnbo3/ygJcb7Q==
@@ -2953,6 +3248,16 @@
     "@comunica/context-entries" "^4.0.2"
     "@comunica/types" "^4.0.2"
     n3 "^1.17.0"
+
+"@comunica/actor-rdf-parse-n3@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.3.0.tgz#fd3c000762984f3144c208760afa202bdbaf2b57"
+  integrity sha512-vUqoztMwpqiiHHYhW0KDBWSdd9hcd4gEu7GehwQxiMcmoIBNSJ6UlQQ29Z8rVMr2vmeTCpCgL4q53sKt8MaYTg==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    n3 "^2.0.0"
 
 "@comunica/actor-rdf-parse-rdfxml@^2.0.1":
   version "2.10.0"
@@ -2963,7 +3268,7 @@
     "@comunica/types" "^2.10.0"
     rdfxml-streaming-parser "^2.2.3"
 
-"@comunica/actor-rdf-parse-rdfxml@^4.0.1", "@comunica/actor-rdf-parse-rdfxml@^4.0.2":
+"@comunica/actor-rdf-parse-rdfxml@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-4.0.2.tgz#f278c4b806a3f8cff0add280959718543af592d5"
   integrity sha512-7TuUXa6108o1nLWrel4xrZjjHtX82nao6vrbIpn22BaF57S4V09x/xOYO9pZdLn3/i5aZ8Lz9aVF2+NGc4VQzA==
@@ -2971,6 +3276,15 @@
     "@comunica/bus-rdf-parse" "^4.0.2"
     "@comunica/context-entries" "^4.0.2"
     rdfxml-streaming-parser "^2.2.3"
+
+"@comunica/actor-rdf-parse-rdfxml@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.3.0.tgz#a6d3da4b511d22efae41e9c3cd61bad656df5abc"
+  integrity sha512-trHmIJ8SGe7hnDZKoyV5mMCZXM0WS2Pg9T+ZmLcZbJPSKIySrhwhSCD83Dc+RW/+oxzYVsj63kh79nScvwZ8wg==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    rdfxml-streaming-parser "^3.2.0"
 
 "@comunica/actor-rdf-parse-shaclc@^2.6.2":
   version "2.10.0"
@@ -2985,7 +3299,7 @@
     shaclc-parse "^1.4.0"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-shaclc@^4.0.1", "@comunica/actor-rdf-parse-shaclc@^4.0.2":
+"@comunica/actor-rdf-parse-shaclc@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-4.0.2.tgz#3b657b80236f28bab4d6d018ffd7b0b10a10b786"
   integrity sha512-DOlz5JbIm5n+SL5hWHjrMud9KpmEsdZT1ybK6OdXI4wZX9NYFeM8QhywgEKUaGhh8gzh2FkcWf5vXfQQfPgGDg==
@@ -2998,6 +3312,19 @@
     readable-stream "^4.5.2"
     shaclc-parse "^1.4.0"
 
+"@comunica/actor-rdf-parse-shaclc@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.3.0.tgz#f5a35c33f3cfa6443e414e20e5b802e52b8e7625"
+  integrity sha512-c0qzFd84DAk09WKbEbaI8ynxeunG0csKBO6CVJ5jfje8Qx9MltUNOP4bMWKQma8Y2Oy7pDoXZOjpJAApQyZ8eQ==
+  dependencies:
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@jeswr/stream-to-string" "^2.0.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+    readable-stream "^4.7.0"
+    shaclc-parse "^2.0.0"
+
 "@comunica/actor-rdf-parse-xml-rdfa@^2.0.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-2.10.0.tgz#e3d1c2d2bf823da6f8a195fa69d22c964e371c48"
@@ -3007,7 +3334,7 @@
     "@comunica/types" "^2.10.0"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-xml-rdfa@^4.0.1", "@comunica/actor-rdf-parse-xml-rdfa@^4.0.2":
+"@comunica/actor-rdf-parse-xml-rdfa@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-4.0.2.tgz#0295dea1f5d7091b005a4fe92ca449677f742c0d"
   integrity sha512-4eRyjMs0SAKI2BgaxLHqvNuRUm0x2uwPTjQr6jO3OqOZTRm8fXsmNfr+/scKRmYANd1OzFEUdcFjAAxYG+pz6g==
@@ -3017,229 +3344,243 @@
     "@comunica/types" "^4.0.2"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-resolve-hypermedia-links-next@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-4.0.2.tgz#c7c73a63425c0fd514cef95617ad7887fc875991"
-  integrity sha512-MOkfI9Zb5VTMWzfA6Pp1GzRdn50ViceAuiakjuNdIejetElEIwIyZcY7N56Y/dMhG1LeUWbMMFMWKdF4Q7d4xQ==
+"@comunica/actor-rdf-parse-xml-rdfa@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.3.0.tgz#f4222777f0da7f33fa411eb62f1e5bf069dbf2d4"
+  integrity sha512-dmtXsCdI1lZ/2zmJD9Tfoj7uUWP+94MIhQkSLB7wqcYQQYQK63dECd98mrI9Ls4NppAukcn3Hg7GqpARdh3XYA==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    rdfa-streaming-parser "^3.0.2"
 
-"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-4.0.2.tgz#178747109bd2162beb29c86504242b520bbc96c6"
-  integrity sha512-bvehXehg+G69eKVWq1r2IWGJLD3Xc68dyq4pMO/Mm5LZ2mT+SPfe/KU8oQMtFkA9xA65m856RTKESUlnK12ZQQ==
+"@comunica/actor-rdf-resolve-hypermedia-links-next@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-next/-/actor-rdf-resolve-hypermedia-links-next-5.3.0.tgz#56694e7fc9391c0f2c92be2f7c6c98079997e9be"
+  integrity sha512-9Kn4H1/o+R4DDA8kbXKuEghVzWtFueb/4JRyTi1RBAc4Bo4ShSz+iVAkV9FEufp7IHnb1qt6FQeKbc+mt53j6g==
   dependencies:
-    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-rdf-resolve-hypermedia-links" "^5.3.0"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/actor-rdf-serialize-jsonld@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-4.0.2.tgz#c63d2c02d2edebc647a17480104988d8ea97fd06"
-  integrity sha512-F/H+Cj7uOnCGg7Wm277Pxcul+UeEld8HeZP7pBTR2Ee6MUtIBm7CJUG/qEKnBEAcH8KpW+ZuWZTfz4yRjWpzxg==
+"@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo/-/actor-rdf-resolve-hypermedia-links-queue-fifo-5.3.0.tgz#0d20822e6e7d93c754aa001431dd46475de8aee2"
+  integrity sha512-ZZLkJeI4lq6hv1CyPKR8FfGJuMu2dKapEhIx6RSZgIIg7hO9mMlmBrS5fWM1zG8it5qPQB2CEOqSGsgAWNKVMA==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    jsonld-streaming-serializer "^3.0.1"
+    "@comunica/bus-rdf-resolve-hypermedia-links-queue" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/actor-rdf-serialize-n3@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-4.0.2.tgz#e3d99fc86060ee6d5f0cdc783e8d432edfe640d6"
-  integrity sha512-2bOBKVMJI8LN9sLfmh3TgaUdQ6KYWCTRwH7teeYZ5mi1bJS/TwzNUVprjUZhQrYNYnXbQvrpjf3RjR8zzU6Grg==
+"@comunica/actor-rdf-serialize-jsonld@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-5.3.0.tgz#e5ab5b2a9db880cd6f9815f25f31f1bb543b8e1e"
+  integrity sha512-Je15V30IuGjHnJYt2/M0dpj7xF0bDaKK3q9QemrZUvfQUBUbt6gyYWzrwSzWoBnimYW5h3tsaTLoNBdl+vPGQg==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^4.0.2"
-    n3 "^1.17.0"
+    "@comunica/bus-rdf-serialize" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    jsonld-streaming-serializer "^4.0.0"
 
-"@comunica/actor-rdf-serialize-shaclc@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-4.0.2.tgz#ac0581d894df8a6946f1d024e17803619a2bc97a"
-  integrity sha512-lkwoHqUu0/d4mi7knjMAG5D+Ck88HCnUhdiCgUV8M/B2ruF5jqkz+9UAh+ORnKeYsjT5MQOd3pdG/xW12PVefA==
+"@comunica/actor-rdf-serialize-n3@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-n3/-/actor-rdf-serialize-n3-5.3.0.tgz#d8b22dcfb0579f9f34676df0a792cf2925662531"
+  integrity sha512-tbMgoM+5fBomE9ScW51FlQ0HuOzmC3aBTVCVTpQOl2s69Jnzeg32hd/pdw/m/WQvIjGRF29ggSRKpHnsydYInQ==
   dependencies:
-    "@comunica/bus-rdf-serialize" "^4.0.2"
+    "@comunica/bus-rdf-serialize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    n3 "^2.0.0"
+
+"@comunica/actor-rdf-serialize-shaclc@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-serialize-shaclc/-/actor-rdf-serialize-shaclc-5.3.0.tgz#3f856976e425d1c8b9ed78b9740a8442b3fd55c0"
+  integrity sha512-zunOoIWCt7Droq2NWwpaapZKQFVqktv7CS+6ISmsiepOligk6Ps2D3F/cRq4IpmEZT9kcRofEXFAy0m9yxLR4A==
+  dependencies:
+    "@comunica/bus-rdf-serialize" "^5.3.0"
     arrayify-stream "^2.0.1"
-    readable-stream "^4.5.2"
-    shaclc-write "^1.4.2"
+    readable-stream "^4.7.0"
+    shaclc-write "^1.6.0"
 
-"@comunica/actor-rdf-update-hypermedia-patch-sparql-update@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-4.0.2.tgz#302872240cc9853d0b84bdb7d84ace05c4554bb5"
-  integrity sha512-wjJYqO4AuUt/I0g4P1f1XVouhLA2gphuHDM04RENvJtyFWJorLmJEIZD5E3Nw1rOEtOXe0sCg2IHDOSuez9siw==
+"@comunica/actor-rdf-update-hypermedia-patch-sparql-update@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-patch-sparql-update/-/actor-rdf-update-hypermedia-patch-sparql-update-5.3.0.tgz#acdcd65a142c236bdad6c4c764d4b23ed0397326"
+  integrity sha512-k/j4iIKW54/lpjxWhwm//B5tikNd29ENTxmgotwM0793ArH55Y5G5ERa82pexMPe/0bLrW9sHRPsG1jhMmTLsA==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-rdf-update-hypermedia" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-rdf-update-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-string-ttl "^1.3.2"
-    readable-stream "^4.5.2"
+    asynciterator "^3.10.0"
+    rdf-string-ttl "^2.0.1"
+    readable-stream "^4.7.0"
 
-"@comunica/actor-rdf-update-hypermedia-put-ldp@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-4.0.2.tgz#5f7f4fc689c872640868ad371e51149dbd9eb6fc"
-  integrity sha512-tZisdTGmeha/x4afuV2tYNP9smna7gp+k66fK+xrXfTGCet/zfTCv6awtpB45a+HA3k3X+40nIF/bQBc0IioRw==
+"@comunica/actor-rdf-update-hypermedia-put-ldp@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-put-ldp/-/actor-rdf-update-hypermedia-put-ldp-5.3.0.tgz#3ca1a40ab0c169650aaeb763cb57725e847bafad"
+  integrity sha512-x5vnFpE1N942NO369hyr8j21L7/TWkLWYPUOsdo0NGi/G4uDRKtYFWwehsYBvBNM+lldwLEDZfXMsHPNu5pXfA==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-rdf-serialize" "^4.0.2"
-    "@comunica/bus-rdf-update-hypermedia" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-rdf-serialize" "^5.3.0"
+    "@comunica/bus-rdf-update-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
+    asynciterator "^3.10.0"
 
-"@comunica/actor-rdf-update-hypermedia-sparql@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-4.0.2.tgz#b20c6dd022ce4429a84b3277ad0a62b6a24273c6"
-  integrity sha512-i7+AC3N7EFmthtfFV1qTqKQXtlcKiU6q3oJ8WJHRe67pZh4bnizHrQoMtbFpCMK5CQkPOusl4PzCBRS6XAa9ow==
+"@comunica/actor-rdf-update-hypermedia-sparql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-hypermedia-sparql/-/actor-rdf-update-hypermedia-sparql-5.3.0.tgz#f9a297bb802321dd956653013d2727f3c7216a41"
+  integrity sha512-UaYwxR7M/8NEmlZvxGx/jAo0ojlu2NJlNmufkbBsKilgL2N6cOQUrr/csFfi/HpjgeiDRT6dc2oOWRP+aBFGOA==
   dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-rdf-update-hypermedia" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-http" "^5.3.0"
+    "@comunica/bus-rdf-update-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@jeswr/stream-to-string" "^2.0.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    fetch-sparql-endpoint "^5.1.0"
-    rdf-string-ttl "^1.3.2"
+    asynciterator "^3.10.0"
+    fetch-sparql-endpoint "^7.1.0"
+    rdf-string-ttl "^2.0.1"
 
-"@comunica/actor-rdf-update-quads-hypermedia@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-4.0.2.tgz#da6dbfd73f283d287597e5834ef67639b7c21d13"
-  integrity sha512-kg7Tm/EByn6FU9vQnuxeZCt0EZDhXuqJNB7QCy8vcOfhM6+Xjkyyscs4mA+5ap1f3ePofdPu+6+DjMu51YYBPw==
+"@comunica/actor-rdf-update-quads-hypermedia@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-hypermedia/-/actor-rdf-update-quads-hypermedia-5.3.0.tgz#3f4f20c3c954c16005dbeee231761cb0e482c75b"
+  integrity sha512-g4w/ah+QRIk4UnOCcaU+TEobiXL4meXNTczneITVHeXytT3EgirFpq1PA/X10M1d18w46P8t4nH8ym1/U6O4vw==
   dependencies:
-    "@comunica/bus-dereference-rdf" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/bus-rdf-metadata" "^4.0.2"
-    "@comunica/bus-rdf-metadata-extract" "^4.0.2"
-    "@comunica/bus-rdf-update-hypermedia" "^4.0.2"
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    lru-cache "^10.0.0"
+    "@comunica/bus-dereference" "^5.3.0"
+    "@comunica/bus-dereference-rdf" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-rdf-metadata" "^5.3.0"
+    "@comunica/bus-rdf-metadata-extract" "^5.3.0"
+    "@comunica/bus-rdf-update-hypermedia" "^5.3.0"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
+    lru-cache "^11.2.2"
 
-"@comunica/actor-rdf-update-quads-rdfjs-store@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-4.0.2.tgz#4a425cbceaf25c1c8c85ee1d272430d0d2a7a1df"
-  integrity sha512-IF/XXK3WZkKmRFpOVsZOVwHj+kvzpk8Sd32vlF+O6UtRtjqND5uPfmoClvVzqwglzXKSL13RTyNvJiM4KW+zNg==
+"@comunica/actor-rdf-update-quads-rdfjs-store@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-update-quads-rdfjs-store/-/actor-rdf-update-quads-rdfjs-store-5.3.0.tgz#998d5ded82a29e93440cf9ec6082c6c28ac63b4a"
+  integrity sha512-NQd2F2MU5Wk6XjDTXHcV1P3Ttv6JzWfTEVpQM+9TcT0S55BTQWcMwJ03KhgHNwrCFFUOc3enQxMhwXL0g4ckIg==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-query-operation" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
+    asynciterator "^3.10.0"
     event-emitter-promisify "^1.1.0"
-    rdf-string "^1.6.1"
+    rdf-string "^2.0.1"
 
-"@comunica/actor-term-comparator-factory-expression-evaluator@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-4.0.2.tgz#95aaf705bc6071da8ea61d02580b70f20b9774d7"
-  integrity sha512-L5/4wcRkqNjX5QllOwz5T7iHw8xLyomHyh3JcCKgVye40ySPjF3TUG5ysJiqMzbWFYE5he8vv2Nt20EpvBvaow==
+"@comunica/actor-term-comparator-factory-expression-evaluator@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/actor-term-comparator-factory-expression-evaluator/-/actor-term-comparator-factory-expression-evaluator-5.3.0.tgz#c1659aadbe589a396c7d7e4e38ed8c11d3064c01"
+  integrity sha512-Qg08JwUHQLjMYlQt5S07Basrd1dPJAIUlW9/NGtvPOrXCu8ukEfVjbPy7KIuz64okmLJUxS5IAcit6OqAl3OoQ==
   dependencies:
-    "@comunica/actor-expression-evaluator-factory-default" "^4.0.2"
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/bus-term-comparator-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/actor-expression-evaluator-factory-default" "^5.3.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/bus-term-comparator-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-bindings-aggregator-factory@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-4.0.2.tgz#73cd5b174e28fddf3986164bee6a50c3b45cba32"
-  integrity sha512-XFpQW3o+Y3Gy5qNlDG4S8gmc3iYwR1tpM9qbcis1biI0f4mjA6dxAW8AAXLy8meMkMVYnaYC1iMWw2mP2ZzrqQ==
+"@comunica/bus-bindings-aggregator-factory@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-bindings-aggregator-factory/-/bus-bindings-aggregator-factory-5.3.0.tgz#25cbdab237e705fdd7c12cb1ccc4876a1c34c711"
+  integrity sha512-SxMOl6Zd9jolBbOIOIqkgLCGIR/6rbL/pCwsDpBU+dcpQPECEQZW51N55/t9R3pSBci20ft8AIUjyv2HC6MkdQ==
   dependencies:
-    "@comunica/bus-expression-evaluator-factory" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
+    "@comunica/bus-expression-evaluator-factory" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
     "@rdfjs/types" "*"
-    rdf-string "^1.6.3"
-    sparqlalgebrajs "^4.2.0"
+    rdf-string "^2.0.1"
 
-"@comunica/bus-context-preprocess@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-4.0.2.tgz#81ba3af31614f6b8a579f5f27b1285f8a2551e47"
-  integrity sha512-pcoQe3/2yDo0HZLMZi7LS6wNFZL2L5SDxPOW8/kG8m4D9KOTa0aTofMTckLxUjikJvjobF5ShK20WTNMFSBtRQ==
+"@comunica/bus-context-preprocess@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-context-preprocess/-/bus-context-preprocess-5.3.0.tgz#47006f80ae75b8190d9336e981bd0171f2bd5fcf"
+  integrity sha512-zEXJE1fzbG652rGTsb4CVfvI+H9B+YwCAXQq6UtMJqelVFFBSYBXMsyzHbYYN5EafRUMyfwtxxETGd4q809/sw==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/bus-dereference-rdf@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-4.0.2.tgz#56070ea8b3a634c84b6f8a30aa50ebb37d80e1e9"
-  integrity sha512-/PXTLDIXqN6hphXQ9aPtvtaca6M48tgkH3o6fZfGW9hUwiMJpX+Oz+ysL0xO/F/Z4BjpZNuZh/xWusX5jLcqNA==
+"@comunica/bus-dereference-rdf@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference-rdf/-/bus-dereference-rdf-5.3.0.tgz#97f38d1f370c3279899c256b8644b5fb95741857"
+  integrity sha512-4e6Ttn8t2Wh1I1GZSVWjs+zfYktNKBLfz7Rniyp9+sJfU5+TzXxKliWCix+dk7P5E+rncJAx3FxGZKn25i5//A==
   dependencies:
-    "@comunica/bus-dereference" "^4.0.2"
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-dereference@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-4.0.2.tgz#c07dce56fbeba4cd4122c9f20e7a883f0c0d1d3f"
-  integrity sha512-D8RDOE23Z4Q2jvD5v7dcMNGgicprRw1ciits7cgB/zOTHufxHNlNZq620TJ9YyOp4zoWqqp/geRAZmLczZrTzQ==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.0.2"
-    "@comunica/actor-abstract-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    readable-stream "^4.5.2"
-
-"@comunica/bus-expression-evaluator-factory@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-4.0.2.tgz#cd6b4a0944128d50ef001cd0cec3df9d348dd7b3"
-  integrity sha512-wW09YZSTdaTWPTUWidVBx85FL3yqrGsYx8bq8koU3lu9KNVEFna4+/t0ts+FqGNSXhRf+XkAvLhEMot52jv+7w==
-  dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.2.0"
-
-"@comunica/bus-function-factory@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-function-factory/-/bus-function-factory-4.0.2.tgz#540f16dadc2723672f480d147f6bb29f61d42a9e"
-  integrity sha512-GLuYJlW2eDs5AMbaJWcgnOHZNkEaEfJgqHiOL8BwOaEK/wa/YsDvwjKLiQuMq/XYkO32ioiN3VRaJUQ5RDd+JA==
-  dependencies:
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-expression-evaluator" "^4.0.2"
-    sparqlalgebrajs "^4.2.0"
-
-"@comunica/bus-hash-bindings@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-4.0.2.tgz#50400947ccff081a362663045d899a467508f8a7"
-  integrity sha512-GI1XfRsIC2dfzLDSQ6GHSmTupnUctiZ2V+5YkI535fBtZTSd1c0Al95l/oIUgTAubd3kl5Vl6qngV2LhV1fBAg==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-dereference" "^5.3.0"
+    "@comunica/bus-rdf-parse" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-hash-quads@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-quads/-/bus-hash-quads-4.0.2.tgz#ff6d8c07e3df0fd0cdb21477a07adece03ad82b9"
-  integrity sha512-dCVntkqVg5Tj4arcAzgk3usJBo68BGUjJYXmcivQQCIAKr/aIXZotnE73Y046IzkBZBKGEs6Meit/198jEmVMg==
+"@comunica/bus-dereference@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-dereference/-/bus-dereference-5.3.0.tgz#e247785e46937bea31f62fcc4aa430e198d061b5"
+  integrity sha512-0Glbh58Xz/2OSM0ZkqWDD7o7TdlRpLjzbcYd15JOyiDReOyG+Kn2j3Ht+e8XkfslEM0UxbCkiK1NjOCMZmnpIg==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    rdf-data-factory "^1.1.2"
+    "@comunica/actor-abstract-mediatyped" "^5.3.0"
+    "@comunica/actor-abstract-parse" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    readable-stream "^4.7.0"
 
-"@comunica/bus-http-invalidate@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-4.0.2.tgz#6758ab6a5a338e4fde6e8071ba4ca89a2835b4d5"
-  integrity sha512-g5YaPWVoZCcbRoMZf+FAP7hVHnPx62pR6eKNu/ooGO7N0qaWb+OOEYAfy/gX64txGA5Mo6PsaqyCXTUAFlVrZA==
+"@comunica/bus-expression-evaluator-factory@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-expression-evaluator-factory/-/bus-expression-evaluator-factory-5.3.0.tgz#34345f594dae0a4df5904955ef07a3539a29ea4f"
+  integrity sha512-5IxLzVAmwv9Aj30F17viNVFQT3EKDWXeTV1WFBLfkxFFiah5fX5gqOTKPVCYgf4n3uAjmcKtEkkRUpXU10a+Ig==
   dependencies:
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+
+"@comunica/bus-function-factory@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-function-factory/-/bus-function-factory-5.3.0.tgz#dca6526f64d118b18ccfe6c6e84a1f5554ea4d59"
+  integrity sha512-s/zSlCwvFLiFqSS+qhYeorOEUD/5CUMm/dJilTZsy1Dct8VYCx6Rk0wbNYkgxlnd91K/xj1ZCgCMITA+m23J5g==
+  dependencies:
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-expression-evaluator" "^5.3.0"
+
+"@comunica/bus-hash-bindings@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-bindings/-/bus-hash-bindings-5.3.0.tgz#293f8e1dbd339f4adcad27700e4ba88fb20a6d73"
+  integrity sha512-Kapq4bVjWEhHm4+c/8K50UdiGMzcePyWeDv9nj9SBRIqu+lnu67Rzwb+zk9KmiHiQKlJqr4EIguaYJqJPuym3w==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-hash-quads@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-hash-quads/-/bus-hash-quads-5.3.0.tgz#437aa29059bca85808463f27d9f32339d8d67d74"
+  integrity sha512-cPblIA/tIgl3Hr/zkEpnckxr9YP3u+8MovWCwOlQ/7qmO8CZQGyhj+g23gzzMstrLG3KtGnFinkXPiYqr1qytg==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    rdf-data-factory "^2.0.0"
+
+"@comunica/bus-http-invalidate@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http-invalidate/-/bus-http-invalidate-5.3.0.tgz#0fd9611cfb6a881c0067df0e84ef86957eaa8a53"
+  integrity sha512-RZw7IEYNLy2DY2fUvXA4CUxzrLeYYofr+soXdKKpvwDYyXqOoNGEZoJP962/RDFORm5hvgZyOWoau5Rg9MAkUg==
+  dependencies:
+    "@comunica/core" "^5.3.0"
 
 "@comunica/bus-http@^2.0.1", "@comunica/bus-http@^2.10.2":
   version "2.10.2"
@@ -3263,6 +3604,18 @@
     readable-from-web "^1.0.0"
     readable-stream-node-to-web "^1.0.1"
 
+"@comunica/bus-http@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-5.3.0.tgz#5f091cfe461d840a107fc40540e2e282d04bdcb8"
+  integrity sha512-/d8FS02Jb5gvFDw21ZiH2Bvt3PRkMN3kkowTRBIArB4wJjt1c7DRXCt2uS7zToNVa0mAdZmKIlC1vpY6g6o3SA==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@jeswr/stream-to-string" "^2.0.0"
+    is-stream "^2.0.1"
+    readable-from-web "^1.0.0"
+    readable-stream-node-to-web "^1.0.1"
+
 "@comunica/bus-init@^2.0.1":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-2.10.0.tgz#9ce88843482cc48e0fb35b6ca40e8f74795d55a5"
@@ -3271,7 +3624,7 @@
     "@comunica/core" "^2.10.0"
     readable-stream "^4.4.2"
 
-"@comunica/bus-init@^4.0.1", "@comunica/bus-init@^4.0.2":
+"@comunica/bus-init@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-4.0.2.tgz#2eb122b434bdf3964183a6199526a68d19601345"
   integrity sha512-sY0C4ri1oBpiEgAD6s7TF/YG8pQz5sYrnOh93M+QDfKxdJiT7NtxRgkxriGBwB1dH6x7KMymogbbW6jXQccv6g==
@@ -3279,141 +3632,166 @@
     "@comunica/core" "^4.0.2"
     readable-stream "^4.5.2"
 
-"@comunica/bus-merge-bindings-context@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-4.0.2.tgz#4c87e4dd7bbeaad92939cb9fab832294bb6e8076"
-  integrity sha512-I2V4SDKaeUp7TwATjhxWF5EnDs4J+9QbL7bZp1l3eIL32d6C190nA3aWTERJKGyf+uGClhjA09EzuJIj1vqMrg==
+"@comunica/bus-init@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-5.3.0.tgz#d7c887ea3c04b41dbac8f804b186bb45f6459f06"
+  integrity sha512-d0Eyp1MhjTAttzBsglLJd3CLi+D7Z3Beat1a396+qdrqXWNV74TFazKMhymSmwwEUZMeyiIR/YttosOkl1ujkw==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    readable-stream "^4.7.0"
 
-"@comunica/bus-optimize-query-operation@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-4.0.2.tgz#c7c25f40d6f2c8c84a23ad622581daacb0f6b40c"
-  integrity sha512-abCJ//r8cw9O0CmUSbgfUySjz79MPwuU3pr0M8+n0I7fDuz8jugt076GvFDbZxvVce8/hv2Qizxrofi6qGahMw==
+"@comunica/bus-merge-bindings-context@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-merge-bindings-context/-/bus-merge-bindings-context-5.3.0.tgz#dd4f292fcc065b52dee9892e280f4db04688872c"
+  integrity sha512-1o8i7aVxWkZhlSEFbbO5YsRvEtQcepRxbrcwovX9qhDpoaZgcEcOIG3cG56+McxD6hZcJoRIJAnOjggmL5rPiw==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/bus-query-operation@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-4.0.2.tgz#c0833ea8d7cc676c5fc98f21448e74648a0f1909"
-  integrity sha512-oAHoM0J77gtOsHAFEyea+ss+DcV8ms16cF0BC/RlmTvv7VUIiQbpT4jI4VwZiBdknNRi4bscHwQWgsaCBbUx3A==
+"@comunica/bus-optimize-query-operation@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-5.3.0.tgz#0b166b7f8ec2ff41d26e17dbc9010ed8642dd124"
+  integrity sha512-YsI+cfmW8Syblu50hs1HrSRZIkW/cZMmdjGlq02kRr9YUyexk05h1mzAblWP1/63VbvTVc42MPkm57JShp5Z0g==
   dependencies:
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/bus-query-parse@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-4.0.2.tgz#bbe09f44674b601f92e0ebbb76c8d3388977699c"
-  integrity sha512-0JyW5jTMg1iXBnKIW4Al9X1Or0TuVgQkyn/mOaiNswvkCH0sSpPS+k/1xF66LgBC/K0RDSiAb5IRytnYM/l1xQ==
+"@comunica/bus-query-operation@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-operation/-/bus-query-operation-5.3.0.tgz#48193c0a0d9725b9f65914b9585ee7460e6ec6df"
+  integrity sha512-acJ87Hsw62NGSCKGbb/YN51zC4d+Tjin3V3DARjnbP7koyltInW8BkNbsZjPr+R5rhvEQbCfxLSuwuk7bg4IIQ==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@rdfjs/types" "*"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/bus-query-process@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-process/-/bus-query-process-4.0.2.tgz#174cea10c92b3b07b3fb179a2bdca2f5afb56aef"
-  integrity sha512-+RJC/zh9jzovGuG/6ba1ihxjCiFOW/QPrYIcVZEB8mA0897c/anWuzCJNWFslLJXP6JDczlQptosRfy3Hj+3vQ==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/bus-query-result-serialize@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-4.0.2.tgz#6af40fe5d563ccc9d7012208907658c5a148f8e9"
-  integrity sha512-NKfmAg8NfZHXz6iDoHEZjo9LpR5GNACZOFITRn2V/TwWoBPPyqj6jJjrO7WYLgEPHYGlzERxvRl5YsCKQgTJ7Q==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/bus-query-source-identify-hypermedia@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-4.0.2.tgz#3b7c581e9e38c1f33f43ff2c510abc22752a4a3e"
-  integrity sha512-l/dOFDZ4+3qJbgLaFVvRLY1Iun2LEqkoBoyv0FTUxJQOf4F+XCpax0E7pD/IRmYSZInYzfG5SiEIX/Vr0wnsLg==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-metadata" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-query-source-identify@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-identify/-/bus-query-source-identify-4.0.2.tgz#9b772772bde9289cdba994c4a3d143b48537c242"
-  integrity sha512-JTBNvrb3kRf2DEdJCganJwdmdCgS4mu83QfoADN3D6IcbrWQccv4X3RiKxjLlQ/6BAqAqqON+ee+8YjWfVcxkw==
+"@comunica/bus-query-parse@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-parse/-/bus-query-parse-5.3.0.tgz#47bf15b343567394711957514c15fbedc278eb33"
+  integrity sha512-DnklxCi7+HjsB/6zmVrupmjQxDEkWydWXBOp++suVjrrxaD0BbOXNwInD33Kr5j9pSMPrBUck0nk8+mHc8JiZA==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-metadata" "^4.0.2"
-    "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    rdf-string "^1.6.3"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/bus-rdf-join-entries-sort@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-4.0.2.tgz#1ca5db13923f64a4007adda1e4c99aad57e7fe42"
-  integrity sha512-Kvs4eBodQi4D2npLufHGdlAGENfE+xC0ftyREM9Q80KTnoKqEds3+XL/o9dIgPv+F/xIaQcs806KRIqdWi44GA==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/bus-rdf-join-selectivity@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-4.0.2.tgz#4807553fa550dc4e23ce5912500e1e9b5ece00e3"
-  integrity sha512-tpwTkBj9Jwx43QODc5CFWRZ+nCLOCS9i6Dp/kHhit6Z+aoUEjdv79gBB5y07O++7fmTKCQWqBnInFALpmuGdTQ==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-accuracy" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/bus-rdf-join@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-4.0.2.tgz#7e8204fee0626ae42a200b22e30b3c9f21e766ce"
-  integrity sha512-0dR3zHHyKlALECCPrXlBz3i+oL4m07ZeSQ2HWCmYmpyfaM85YmcWSO76o9cr5Z59S7MylNKCuurziQ9nQl1eyA==
-  dependencies:
-    "@comunica/bus-rdf-join-entries-sort" "^4.0.2"
-    "@comunica/bus-rdf-join-selectivity" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-iterator" "^4.0.1"
-    "@comunica/utils-metadata" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-metadata-accumulate@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-4.0.2.tgz#e59292acad14dad44ea220a4183327281816588c"
-  integrity sha512-pejPn7TuQqmcAzZ/9k1r+/2TIIRyAMAyKfaoEdqDkjOOJ/SZOs4xqz8xKmiU7LocL1wEE0YYHHhzS1ChMcL2IQ==
+"@comunica/bus-query-process@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-process/-/bus-query-process-5.3.0.tgz#7289ad2e5a0d16cd50c6d9a4c1580f3818cfa477"
+  integrity sha512-NOpHUBA3qxF9Y4vmHaGlnGnGxPUNthT9GdkvT3jyH3ykU8RPIbrpeRZfS5Kdv2rj3Z/EvTlUXIEF63ENdAReAA==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
 
-"@comunica/bus-rdf-metadata-extract@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-4.0.2.tgz#e98b0f551097e8661672d86f0d06e15ba1b829a2"
-  integrity sha512-G89JF8891zcL9Jo8I0ZhGg92XGRAkiHIgXqrSrFBEkRK35q1gAh/hASJFUnWyOZfPZ+aJCuZLQ5l232uA2FxTQ==
+"@comunica/bus-query-result-serialize@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-result-serialize/-/bus-query-result-serialize-5.3.0.tgz#77b1b505d3e95178f778f23cdc2a0d2989ffb785"
+  integrity sha512-jWz0031xw1AfdgdpvDPAGV1s1jkK9wSMY5dm3kAAn9bzudLOQekvxyMDUiX5Wrk7nF4xDo/CZO1HsCX6eLCOtw==
   dependencies:
-    "@comunica/core" "^4.0.2"
+    "@comunica/actor-abstract-mediatyped" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/bus-query-serialize@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-serialize/-/bus-query-serialize-5.3.0.tgz#f19923136b0196dffe7203aeb91b1b18e6973491"
+  integrity sha512-WRFiNpaleI+XmAOnHvevuRT89Ei39B6od09ZN4rNLybHa7BzRvOBfnwyu2joeK9+VDc4rD2/cqjLnVIpDMbd7A==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-metadata@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-4.0.2.tgz#5e63b915326189736fba35a4bfa3d4f9481134e6"
-  integrity sha512-KUYadz8uO/rJOIpF1NTLvedhSVkVmNiiHX+KNpDk2KWydAvsHpTrY+F260+ZFKFaE/fINoIUF660TgDL6Kq1iQ==
+"@comunica/bus-query-source-dereference-link@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-dereference-link/-/bus-query-source-dereference-link-5.3.0.tgz#57073c17506433d1687e735286dd9a85ecb7a2b0"
+  integrity sha512-okwvE+pPcFc0Njt7VplV1sVREGSdPVlDqh2aMS0ESHx3O0lFBjWiPr0MwhhoBnzhplJ/WQfLyESZumDNFayehA==
   dependencies:
-    "@comunica/core" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/bus-query-source-identify-hypermedia@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-identify-hypermedia/-/bus-query-source-identify-hypermedia-5.3.0.tgz#94f1ae02f3c423b72edb8488d46331bac22e8e84"
+  integrity sha512-tbu0dGoqJTLJF0eTFSdPY5uQOrvTYqbvlExzRWcUiF1NEHw3TH065QsDtL6PKlWCQWmyWRp/uzdgdPvPx1utaQ==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-query-source-identify@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-query-source-identify/-/bus-query-source-identify-5.3.0.tgz#aa644b8e5001b1b8d42da820be5ce04824123ae0"
+  integrity sha512-7tMFWemw1CojMqYwJpd42ojZA5QZQCN1/ITDTuUVTh1stny+siCTpAmqMLAwxpKs2AWeuj9ytkUGd/jk8zH6Ww==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+    rdf-string "^2.0.1"
+    rdf-terms "^2.0.0"
+
+"@comunica/bus-rdf-join-entries-sort@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-entries-sort/-/bus-rdf-join-entries-sort-5.3.0.tgz#79be27a20fcc9d5f4b4b3e2820ac6d9bef3cce40"
+  integrity sha512-J5ivYZTKWy61W0KwuxBCbgNlNaX+acJTUaS5s/pR5SLrrMDE19yBaJAgOAP8bPlW19IPnqjMuvmrAhGRes/qyA==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/bus-rdf-join-selectivity@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join-selectivity/-/bus-rdf-join-selectivity-5.3.0.tgz#8d4d14ee69212207064a58f1cafc14e839eb6159"
+  integrity sha512-vH3RVitPhWEBGOPgA3Utq4eOT2YJXYAsLMShH9fmckW+Gyn8gHkn/bvUyX3XX3eC0eFhOno3reCUQWXjgcOmfw==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-accuracy" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/bus-rdf-join@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-join/-/bus-rdf-join-5.3.0.tgz#84e1db64809d9d6bcc5e40ee58538382181edf7f"
+  integrity sha512-frR1cwzcM6knfkxMB0kLgTc31N2dU3XhK4DeZhbkXtj8Nyu2g7YMhrU/HEOToNj/lrr4/utxsisg63c9e2/IUg==
+  dependencies:
+    "@comunica/bus-rdf-join-entries-sort" "^5.3.0"
+    "@comunica/bus-rdf-join-selectivity" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-iterator" "^5.0.0"
+    "@comunica/utils-metadata" "^5.3.0"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-rdf-metadata-accumulate@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-accumulate/-/bus-rdf-metadata-accumulate-5.3.0.tgz#4a23261968fa47b57927a648e14b5edf734a724c"
+  integrity sha512-qQFIhWFvqNVT3Lbfe+gF8pWFEyFGhZ4nHRBbSYuhfF53Uq4odEwx/NwFkbrPqH4QWAnKy+uqUCr1RTvNa/0Zyg==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/bus-rdf-metadata-extract@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata-extract/-/bus-rdf-metadata-extract-5.3.0.tgz#ddd95dcb78deb28586bc3390d3bda6eedf83c5d2"
+  integrity sha512-Qcvs7JBiyUFol0EMO7YDCcyRYbDWRDz1mAslOdIhdK67Rl2vX5sbMaddXz7yuT+Ramjapk/3sNrqGdJCK435yg==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-rdf-metadata@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-metadata/-/bus-rdf-metadata-5.3.0.tgz#012a68564752f4fef62bc71d2e02ef57b5372014"
+  integrity sha512-wGOngtA4JtW+hegdMpkydVlLDlnguMgk3WpZFxOnC0l8rYmsJ0t/coo1eIBnv5/He2BtTRXsbEUP5Dz8RWt7DQ==
+  dependencies:
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse-html@^2.0.1", "@comunica/bus-rdf-parse-html@^2.10.0":
@@ -3430,6 +3808,14 @@
   integrity sha512-PatbiwlgNwMmAFd9UAtzAPrcFhv9PS92UVvyTeML/mNDXCQfUZ9L3bRyQN6DrItYBWTxxCGLkybTSGL4DojwMw==
   dependencies:
     "@comunica/core" "^4.0.2"
+    "@rdfjs/types" "*"
+
+"@comunica/bus-rdf-parse-html@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.3.0.tgz#e57c4eb8cc3aa853e59466fc765867b1b9518684"
+  integrity sha512-P2I8pW/ze2/9b+QQK4cW/j/c4DxAQ7ttto+FTQVwejrgT7doEBWR0niaYEiBOrQo0OirjVbakwbWfGZ57dC0vg==
+  dependencies:
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
 
 "@comunica/bus-rdf-parse@^2.0.1", "@comunica/bus-rdf-parse@^2.10.0":
@@ -3452,60 +3838,70 @@
     "@comunica/core" "^4.0.2"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-resolve-hypermedia-links-queue@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-4.0.2.tgz#90356e85d89accf658b034a6ff687054beaae15a"
-  integrity sha512-V/CmzExnPHi63IpSpTBMWHct8mp1RG4eydmVlgYJPUX75kUAGLh8MqGcJYoJlN6MdzC7/8eNdRM1e80fSCfR0Q==
+"@comunica/bus-rdf-parse@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.3.0.tgz#3f7b2b10a6f39fa4644df230743240a00d630261"
+  integrity sha512-t8bRBDUqNAAMB80zpz40gyMhgRcWY72m3TdjT7NxzRzet1QrvHwHSk3OKsnaaoAq1IPooAsW9LWtnl1mGwoY/A==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/bus-rdf-resolve-hypermedia-links@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-4.0.2.tgz#dff171851e30da1b732c3da5b06402997f62b2be"
-  integrity sha512-f0sYSNn9tbM/xA/PzQrusLgY4BvR6Ajf1oVGL47pcVk6JvNSWoWUZWspmpYGnxJFoUFUuRfWEq3hjVpvzqve6w==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/bus-rdf-serialize@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-4.0.2.tgz#07c212d56533a508b28770c63b8929cc3b1143e8"
-  integrity sha512-e4Z3JaZ30iVWgHjehh+0nK5+x292HEKsHpSsTETzWZz6e0g1gkfZDzUMAB3cNiensvD6XPpXKSUnwqP2Lfz4UA==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/actor-abstract-mediatyped" "^5.3.0"
+    "@comunica/actor-abstract-parse" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-update-hypermedia@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-4.0.2.tgz#f0faf87894311ca14479ad466ca940fc562a5387"
-  integrity sha512-22/+sGV43WmNv8sRTxRPgT4sDNir0gNboJoBvazR4avFFBWf5CLVkya75Zi4W8ZhZQPQOqmeWyXwt7qBaOx87A==
+"@comunica/bus-rdf-resolve-hypermedia-links-queue@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links-queue/-/bus-rdf-resolve-hypermedia-links-queue-5.3.0.tgz#3c5d195211d99a2373bd6ecfda0d84a2790e702e"
+  integrity sha512-EbIeIYnhkKymvzsTviTZzTChMpjdKI3fI6v1LPZb0j+L0qGi/Xt5QjF87u9FCGIJgtbRzOdjSgSFP+FBwVcgLQ==
   dependencies:
-    "@comunica/bus-rdf-update-quads" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/bus-rdf-update-quads@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-4.0.2.tgz#060115113dab105b18196d433a052f04cdf82e3a"
-  integrity sha512-DRouh8TXfsDy/CkmVS9q9Pfu8LD4/6Q43QQAk2kWevobcxmV5nEAILOooutTxSxn8/nVp9aUgOiGmslGD6uKRw==
+"@comunica/bus-rdf-resolve-hypermedia-links@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-resolve-hypermedia-links/-/bus-rdf-resolve-hypermedia-links-5.3.0.tgz#19ce8eeb69aaea1da4d5809f654b4bb6d00b3ebf"
+  integrity sha512-r+MClePIZDCI37vr9eIPR9BGvH5MUVeC5EX6CXSAOlgqULCj4kIaW/KA5NxvShMi4lnw3ErGNjXVuixpxerOpw==
   dependencies:
-    "@comunica/actor-context-preprocess-query-source-skolemize" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+
+"@comunica/bus-rdf-serialize@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-serialize/-/bus-rdf-serialize-5.3.0.tgz#ada1ba34f053ccb321dfb1ae3b05ea2f3a876c8d"
+  integrity sha512-kcGy/GkKL0/qh90VWJTORFt5HEUJ/g+VG/YElLxh7ZhAaeDcmm7XiTZ+lJM71l2x5k38NRLpzdAREnrLdxMBpQ==
+  dependencies:
+    "@comunica/actor-abstract-mediatyped" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
 
-"@comunica/bus-term-comparator-factory@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-4.0.2.tgz#2180e8ed2f0b406bc664de30b27dcb63162c8a56"
-  integrity sha512-fJaRUmR/0TiW3ky8eIapo72llk28dkHkY5EkELQpCaZLH5aFMO5ArbHBKae2YtardbKqZz74K5K5FwxCUSQn8w==
+"@comunica/bus-rdf-update-hypermedia@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-hypermedia/-/bus-rdf-update-hypermedia-5.3.0.tgz#9b2b313edbce2eff9b8f23fcb582a029840a7ef8"
+  integrity sha512-AyDiuo2GgWksamkLYudJ9rRCeCSffDNWgWeH2/KV0i8gTXku/qNFFC2yk3Y/y4Akpz7AYFdyJzv4iZShmJUxOA==
   dependencies:
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-rdf-update-quads" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/bus-rdf-update-quads@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-update-quads/-/bus-rdf-update-quads-5.3.0.tgz#5812a63146b1ccbb3e1309bd4d6ae8daa784fc23"
+  integrity sha512-3GiRK60Cdnu0jnk7ux9EZBy/GlfsKCITReuFiAQEwUQs5nqRHq2MQ+f8gjaVICc9L50jICNGOXHRn095IFskpA==
+  dependencies:
+    "@comunica/actor-optimize-query-operation-query-source-skolemize" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+
+"@comunica/bus-term-comparator-factory@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/bus-term-comparator-factory/-/bus-term-comparator-factory-5.3.0.tgz#0537a5d0a50c9ec99608afcc36ecc9e94138f513"
+  integrity sha512-Xk61lo643QXfH9f34M7vNdaOART32Gjp3R6IdOsLqgCmrwM0FtvUt8UB+FWgTV4G6n8aRJwFw2e8M9v3kw3obg==
+  dependencies:
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
 
 "@comunica/config-query-sparql@^2.0.1":
@@ -3517,6 +3913,11 @@
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-4.0.1.tgz#ad7da2b3636aaf7dd3eb5b4918c76ac3bf2c61d7"
   integrity sha512-jNuRl7PmOKillPfvIzmO+I7IFP0nroFQrZaX/4pUIqe4WNrSCzjZqrLnru0BQtFE5LXcaEA9IdtISSfjwTFt2w==
+
+"@comunica/config-query-sparql@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-5.3.0.tgz#4be54d2893a3906ac190a1f6af0f7318d47b75fb"
+  integrity sha512-5snTR5p0yjQCIiRrNu6tzNAD1EfahkSNmQUB2AUI04S/lfz97HQ1ycvQroeJ7P08goyBtld2s0AReexUnNhcfw==
 
 "@comunica/context-entries@^2.10.0":
   version "2.10.0"
@@ -3540,6 +3941,17 @@
     jsonld-context-parser "^2.2.2"
     sparqlalgebrajs "^4.3.8"
 
+"@comunica/context-entries@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-5.3.0.tgz#58e9a930ea6f5f2ea0a09fd8d04302aac2eb93e4"
+  integrity sha512-B4KXcYgYDrg1HCl1kCyhHM2I/xvyJsSbf8bxHY2xWnaqqytLJPyyMffKdHFRflHc1JmlqpYV6vyc4+5ZBUWzAw==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@rdfjs/types" "*"
+    jsonld-context-parser "^2.2.2"
+
 "@comunica/core@^2.0.1", "@comunica/core@^2.10.0":
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/@comunica/core/-/core-2.10.0.tgz#198c176443d03d6b374ee2b11fdd862b4b7c2b63"
@@ -3556,28 +3968,36 @@
     "@comunica/types" "^4.0.2"
     immutable "^4.3.7"
 
-"@comunica/logger-pretty@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-4.0.2.tgz#70c775ff3f6b7b2a26e77077921f3f6f08a65e33"
-  integrity sha512-7rH9bJUaslQYUv0MR3spfILogH982Q+uUh0zBNm5WYKIEn7eO9JTXKmdlde3YycDrMNy8lDp3M5K75gfpreedw==
+"@comunica/core@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-5.3.0.tgz#06f3022747762ee43a14f8f5de9aaf9734c21e01"
+  integrity sha512-f3TIl78jS/Td4b7jcXm8Ps2aTz70yujgrMn2vYKg6YLcvumA7yVJ5yVvgDz+jhv7wnQfk8yJfnzi2PYwuM4UMw==
   dependencies:
-    "@comunica/types" "^4.0.2"
+    "@comunica/types" "^5.3.0"
+    immutable "^5.1.3"
+
+"@comunica/logger-pretty@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-pretty/-/logger-pretty-5.3.0.tgz#ae7797e92570450301dd5b40fdb91d535340b051"
+  integrity sha512-GcpITJMRzlnOCJ8XbiKWIFQZJ1a6SyCHo5Yb/aXW24JIS7F4DFmogKdywQSffPnxT+0qTFPJn8ZDPaMeLfp1Jg==
+  dependencies:
+    "@comunica/types" "^5.3.0"
     object-inspect "^1.12.2"
     process "^0.11.10"
 
-"@comunica/logger-void@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-4.0.2.tgz#49eb46b3592a7fab5d0f941778e90a6ee89eec3b"
-  integrity sha512-vgZtrhKajyNITvWQ++EKGdS7fzWXgE8NvlTIrdX1vYcDQBYFq6ywbzNx62EpIYlnN9ANpNA/JY0QS9Fn2WunoQ==
+"@comunica/logger-void@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/logger-void/-/logger-void-5.3.0.tgz#d15658f65e41718412651add13dde1ab5e195b12"
+  integrity sha512-/AY/8lT7A33nEtJ1bKgecVF52zR8mj6WQKoEM2RDvDG3ZKjwVDy3uZd2rOiz18lN58YHL7sCN1bxyrVGgjc40g==
   dependencies:
-    "@comunica/types" "^4.0.2"
+    "@comunica/types" "^5.3.0"
 
-"@comunica/mediator-all@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-4.0.2.tgz#5d691e47ee9e2dccd350f5fefbc8c7df56ef722a"
-  integrity sha512-Dyfemkx2fAq1eOKR9r4PkFel/e/fA0L00x1ldqLsc4p5q7vysAloju4a2Ijgc1GYbBpZl94SM7QJfiOXFEdNng==
+"@comunica/mediator-all@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-all/-/mediator-all-5.3.0.tgz#67fe95924c7bfea8adea06ba832f5a93e717aa44"
+  integrity sha512-Fl2VqjdMGZSdqxJ/QkShgTH+kO0m0J3wiMGI1nzB4eSxqcJi8vI/AFDmlEnlodGR8xQyRKTM54/PVF6HUdd96w==
   dependencies:
-    "@comunica/core" "^4.0.2"
+    "@comunica/core" "^5.3.0"
 
 "@comunica/mediator-combine-pipeline@^2.0.1":
   version "2.10.0"
@@ -3587,13 +4007,21 @@
     "@comunica/core" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/mediator-combine-pipeline@^4.0.1", "@comunica/mediator-combine-pipeline@^4.0.2":
+"@comunica/mediator-combine-pipeline@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.0.2.tgz#dcd3ddfd10fcc81b272bb2304ec67017456dada3"
   integrity sha512-bU66ZgbP0v7SznZ3SGQXabYsQbUUErrT++WSDfv9w/jm7UJidt8mpRZfPTD0q83Cxu+yfOU5c9ToSVMT93CLGg==
   dependencies:
     "@comunica/core" "^4.0.2"
     "@comunica/types" "^4.0.2"
+
+"@comunica/mediator-combine-pipeline@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.3.0.tgz#a2a926073dace06ddbf9824020fc78b961fd6286"
+  integrity sha512-I3OzVq2HlFOREEUBm5r4Hs8J1gDGyL4Ms45e2gJfEfuQuMKIIdCeUkdLrqHhqA1xgryybFV2PZ2bD7L6V2/xVw==
+  dependencies:
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
 "@comunica/mediator-combine-union@^2.0.1":
   version "2.10.0"
@@ -3602,23 +4030,30 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-combine-union@^4.0.1", "@comunica/mediator-combine-union@^4.0.2":
+"@comunica/mediator-combine-union@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-4.0.2.tgz#f2b3b4b9da6b90934a890f2acacc0ebf2061607e"
   integrity sha512-upb0h6pWgithAvTH9iTa8lVQkUaI4a/+f7oh/F3suBULOA3mlACLp3eQU8w9tUnnKYujI7+sW9lH9uRkF34o7A==
   dependencies:
     "@comunica/core" "^4.0.2"
 
-"@comunica/mediator-join-coefficients-fixed@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-4.0.2.tgz#5394efb0a1e49f74d5463f631a4a9b7427bcd14e"
-  integrity sha512-1/VfgeGq8MkQ0rlB7kbmtfSX1ORHMzWMW74/o43+LQax3gyNMjgObkH4jrjHRl3bpSgkLOwak1G8l322dimFAA==
+"@comunica/mediator-combine-union@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-5.3.0.tgz#f4effdd6840914fc0ad6d4940c45dced4e6a6043"
+  integrity sha512-us4Ficcn9dMfeMAWPYaM386hwsWzBjYF2VClSkCn3hQW8G702HOs384pxFA5CDaqUUpn2HZZdokM72S8JTMFCg==
   dependencies:
-    "@comunica/bus-rdf-join" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-join-coefficients" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/mediator-join-coefficients-fixed@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-join-coefficients-fixed/-/mediator-join-coefficients-fixed-5.3.0.tgz#233941d6cf2acbffde4ed254e442abb2b3f465d4"
+  integrity sha512-oqMfzit7DD6vwGxxLtFf5gBZVrVvLRGe6scksmnp32aq4RWPv5/PLg2DmsCq8bRIzKnMG4kDJaFh9aSBAmXG8g==
+  dependencies:
+    "@comunica/bus-rdf-join" "^5.3.0"
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/mediatortype-join-coefficients" "^5.3.0"
+    "@comunica/types" "^5.3.0"
 
 "@comunica/mediator-number@^2.0.1":
   version "2.10.0"
@@ -3627,12 +4062,19 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-number@^4.0.1", "@comunica/mediator-number@^4.0.2":
+"@comunica/mediator-number@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-4.0.2.tgz#c3e7b8210f00c4bd83435e09cfafa9f3dfe47829"
   integrity sha512-m4aLqDtxvM8bZjFlgkoStYczyLnZ+bobx7LcVnj0j3Kws50UMU+k44brToi20i55oYcxi4T3zm4fjLrM6nBRcQ==
   dependencies:
     "@comunica/core" "^4.0.2"
+
+"@comunica/mediator-number@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-5.3.0.tgz#5a313ff91e39f97a342c8b967024a638b99816fa"
+  integrity sha512-Mb21LNiMZfjN4fF9st7eBpupX+AdrPLSrzJ8jquv5N5jK3ss8ctAPU6Kqs8c6DLkTmdfGIqUt9lQMQ7fodgj1A==
+  dependencies:
+    "@comunica/core" "^5.3.0"
 
 "@comunica/mediator-race@^2.0.1":
   version "2.10.0"
@@ -3641,26 +4083,33 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-race@^4.0.1", "@comunica/mediator-race@^4.0.2":
+"@comunica/mediator-race@^4.0.1":
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-4.0.2.tgz#89b0992037b7bb3eb7caa5c5de3b583670613129"
   integrity sha512-gzPRxWZaWwBEzfKPy3Qhuk1oDLd4hE+AvAbA4rE7xICmF4sgU/wSHiBM809vhi6HE818d509xFwEB9R/gXDNNQ==
   dependencies:
     "@comunica/core" "^4.0.2"
 
-"@comunica/mediatortype-accuracy@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-4.0.2.tgz#70cf90d009109fc3ca8061a17549abc6de7ef0db"
-  integrity sha512-Eh/O+hsHCCXNkB3CVO4ppdj1PvcMYlfyiYCWVS68EnydqMfFThxuMLwervtc7to+vysa85FQwDj4ADwUeum1pg==
+"@comunica/mediator-race@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-5.3.0.tgz#8c2ebac45716361bdaaf9ae38878dbd392c19cdf"
+  integrity sha512-m66N9pMJ5FHS4Pt8arLyIS85cfDsXmhAcUxUVbxQw1+hAfBoQKRmWfZdTqdW55d9xeMxZysGFV1w3k5aar4SKA==
   dependencies:
-    "@comunica/core" "^4.0.2"
+    "@comunica/core" "^5.3.0"
 
-"@comunica/mediatortype-join-coefficients@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-4.0.2.tgz#531e4115d78f48b87a74189f66d3ec41c7f2ee83"
-  integrity sha512-Y1rOaKiHHr9PA7LnLpb51X/9LiweXZ/GSjRB0bMbrp4foG+HRL6Rlw/r7JcP1uFe3Xf8WfxyvV9zAW13fI/3aw==
+"@comunica/mediatortype-accuracy@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-accuracy/-/mediatortype-accuracy-5.3.0.tgz#15bd0967f36e19469f679c8597abc9ea9f011c55"
+  integrity sha512-+A9HiGR4iIu95xSGysrJSzKvCkxY7mXZOO96by0cr3ZqbaCuCcHNBlxQLQcPWHExLz7eo1t+43KLUB3DkzSRig==
   dependencies:
-    "@comunica/core" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/mediatortype-join-coefficients@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-join-coefficients/-/mediatortype-join-coefficients-5.3.0.tgz#20b347ef65c379f53aabfd454ae08e2aa2ea0d5d"
+  integrity sha512-v3iZCMrnjtBoXkYIdLg/9PDI0SZTVvk/txuMS9k4BNS9hp+e8FE73HmufH8oLdkQ8vxHCIY/G6cacqAn0eEMnA==
+  dependencies:
+    "@comunica/core" "^5.3.0"
     "@rdfjs/types" "*"
 
 "@comunica/mediatortype-time@^2.10.0":
@@ -3677,271 +4126,296 @@
   dependencies:
     "@comunica/core" "^4.0.2"
 
-"@comunica/query-sparql@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/query-sparql/-/query-sparql-4.0.2.tgz#0cb44c96c8ae3e56440547f5ccd96c94a51e0e2f"
-  integrity sha512-BuTccCsBrskzY8yy7K6WJ+IlZqfEugSiEd9nq7s6Y9wszBsF4KVEFkrPFgF1w+v+kYkre0o7M/nKuErCB9mzFg==
+"@comunica/mediatortype-time@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-time/-/mediatortype-time-5.3.0.tgz#9e1faaeb42d61e91e0f4526fcad859ab3f0c00b5"
+  integrity sha512-5OF11XzzolSbD2L0pA9QQdrYa3VGCge0eH88uBD8wYh/7UChOmo3J6lVjWE9Ct2GEWosJc1kUa33iu7Dfy962g==
   dependencies:
-    "@comunica/actor-bindings-aggregator-factory-average" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-count" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-group-concat" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-max" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-min" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-sample" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-sum" "^4.0.2"
-    "@comunica/actor-bindings-aggregator-factory-wildcard-count" "^4.0.2"
-    "@comunica/actor-context-preprocess-convert-shortcuts" "^4.0.2"
-    "@comunica/actor-context-preprocess-query-source-identify" "^4.0.2"
-    "@comunica/actor-context-preprocess-query-source-skolemize" "^4.0.2"
-    "@comunica/actor-context-preprocess-set-defaults" "^4.0.2"
-    "@comunica/actor-context-preprocess-source-to-destination" "^4.0.2"
-    "@comunica/actor-dereference-fallback" "^4.0.2"
-    "@comunica/actor-dereference-http" "^4.0.2"
-    "@comunica/actor-dereference-rdf-parse" "^4.0.2"
-    "@comunica/actor-expression-evaluator-factory-default" "^4.0.2"
-    "@comunica/actor-function-factory-expression-bnode" "^4.0.2"
-    "@comunica/actor-function-factory-expression-bound" "^4.0.2"
-    "@comunica/actor-function-factory-expression-coalesce" "^4.0.2"
-    "@comunica/actor-function-factory-expression-concat" "^4.0.2"
-    "@comunica/actor-function-factory-expression-extensions" "^4.0.2"
-    "@comunica/actor-function-factory-expression-if" "^4.0.2"
-    "@comunica/actor-function-factory-expression-in" "^4.0.2"
-    "@comunica/actor-function-factory-expression-logical-and" "^4.0.2"
-    "@comunica/actor-function-factory-expression-logical-or" "^4.0.2"
-    "@comunica/actor-function-factory-expression-not-in" "^4.0.2"
-    "@comunica/actor-function-factory-expression-same-term" "^4.0.2"
-    "@comunica/actor-function-factory-term-abs" "^4.0.2"
-    "@comunica/actor-function-factory-term-addition" "^4.0.2"
-    "@comunica/actor-function-factory-term-ceil" "^4.0.2"
-    "@comunica/actor-function-factory-term-contains" "^4.0.2"
-    "@comunica/actor-function-factory-term-datatype" "^4.0.2"
-    "@comunica/actor-function-factory-term-day" "^4.0.2"
-    "@comunica/actor-function-factory-term-division" "^4.0.2"
-    "@comunica/actor-function-factory-term-encode-for-uri" "^4.0.2"
-    "@comunica/actor-function-factory-term-equality" "^4.0.2"
-    "@comunica/actor-function-factory-term-floor" "^4.0.2"
-    "@comunica/actor-function-factory-term-greater-than" "^4.0.2"
-    "@comunica/actor-function-factory-term-greater-than-equal" "^4.0.2"
-    "@comunica/actor-function-factory-term-hours" "^4.0.2"
-    "@comunica/actor-function-factory-term-inequality" "^4.0.2"
-    "@comunica/actor-function-factory-term-iri" "^4.0.2"
-    "@comunica/actor-function-factory-term-is-blank" "^4.0.2"
-    "@comunica/actor-function-factory-term-is-iri" "^4.0.2"
-    "@comunica/actor-function-factory-term-is-literal" "^4.0.2"
-    "@comunica/actor-function-factory-term-is-numeric" "^4.0.2"
-    "@comunica/actor-function-factory-term-is-triple" "^4.0.2"
-    "@comunica/actor-function-factory-term-lang" "^4.0.2"
-    "@comunica/actor-function-factory-term-langmatches" "^4.0.2"
-    "@comunica/actor-function-factory-term-lcase" "^4.0.2"
-    "@comunica/actor-function-factory-term-lesser-than" "^4.0.2"
-    "@comunica/actor-function-factory-term-lesser-than-equal" "^4.0.2"
-    "@comunica/actor-function-factory-term-md5" "^4.0.2"
-    "@comunica/actor-function-factory-term-minutes" "^4.0.2"
-    "@comunica/actor-function-factory-term-month" "^4.0.2"
-    "@comunica/actor-function-factory-term-multiplication" "^4.0.2"
-    "@comunica/actor-function-factory-term-not" "^4.0.2"
-    "@comunica/actor-function-factory-term-now" "^4.0.2"
-    "@comunica/actor-function-factory-term-object" "^4.0.2"
-    "@comunica/actor-function-factory-term-predicate" "^4.0.2"
-    "@comunica/actor-function-factory-term-rand" "^4.0.2"
-    "@comunica/actor-function-factory-term-regex" "^4.0.2"
-    "@comunica/actor-function-factory-term-replace" "^4.0.2"
-    "@comunica/actor-function-factory-term-round" "^4.0.2"
-    "@comunica/actor-function-factory-term-seconds" "^4.0.2"
-    "@comunica/actor-function-factory-term-sha1" "^4.0.2"
-    "@comunica/actor-function-factory-term-sha256" "^4.0.2"
-    "@comunica/actor-function-factory-term-sha384" "^4.0.2"
-    "@comunica/actor-function-factory-term-sha512" "^4.0.2"
-    "@comunica/actor-function-factory-term-str" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-after" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-before" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-dt" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-ends" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-lang" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-len" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-starts" "^4.0.2"
-    "@comunica/actor-function-factory-term-str-uuid" "^4.0.2"
-    "@comunica/actor-function-factory-term-sub-str" "^4.0.2"
-    "@comunica/actor-function-factory-term-subject" "^4.0.2"
-    "@comunica/actor-function-factory-term-subtraction" "^4.0.2"
-    "@comunica/actor-function-factory-term-timezone" "^4.0.2"
-    "@comunica/actor-function-factory-term-triple" "^4.0.2"
-    "@comunica/actor-function-factory-term-tz" "^4.0.2"
-    "@comunica/actor-function-factory-term-ucase" "^4.0.2"
-    "@comunica/actor-function-factory-term-unary-minus" "^4.0.2"
-    "@comunica/actor-function-factory-term-unary-plus" "^4.0.2"
-    "@comunica/actor-function-factory-term-uuid" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-boolean" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-date" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-datetime" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-day-time-duration" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-decimal" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-double" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-duration" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-float" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-integer" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-string" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-time" "^4.0.2"
-    "@comunica/actor-function-factory-term-xsd-to-year-month-duration" "^4.0.2"
-    "@comunica/actor-function-factory-term-year" "^4.0.2"
-    "@comunica/actor-hash-bindings-murmur" "^4.0.2"
-    "@comunica/actor-hash-quads-murmur" "^4.0.2"
-    "@comunica/actor-http-fetch" "^4.0.2"
-    "@comunica/actor-http-proxy" "^4.0.2"
-    "@comunica/actor-http-retry" "^4.0.2"
-    "@comunica/actor-http-wayback" "^4.0.2"
-    "@comunica/actor-init-query" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-assign-sources-exhaustive" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-bgp-to-join" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-construct-distinct" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-describe-to-constructs-subject" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-filter-pushdown" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-group-sources" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-join-bgp" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-join-connected" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-prune-empty-source-operations" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-rewrite-add" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-rewrite-copy" "^4.0.2"
-    "@comunica/actor-optimize-query-operation-rewrite-move" "^4.0.2"
-    "@comunica/actor-query-operation-ask" "^4.0.2"
-    "@comunica/actor-query-operation-bgp-join" "^4.0.2"
-    "@comunica/actor-query-operation-construct" "^4.0.2"
-    "@comunica/actor-query-operation-distinct-hash" "^4.0.2"
-    "@comunica/actor-query-operation-extend" "^4.0.2"
-    "@comunica/actor-query-operation-filter" "^4.0.2"
-    "@comunica/actor-query-operation-from-quad" "^4.0.2"
-    "@comunica/actor-query-operation-group" "^4.0.2"
-    "@comunica/actor-query-operation-join" "^4.0.2"
-    "@comunica/actor-query-operation-leftjoin" "^4.0.2"
-    "@comunica/actor-query-operation-minus" "^4.0.2"
-    "@comunica/actor-query-operation-nop" "^4.0.2"
-    "@comunica/actor-query-operation-orderby" "^4.0.2"
-    "@comunica/actor-query-operation-path-alt" "^4.0.2"
-    "@comunica/actor-query-operation-path-inv" "^4.0.2"
-    "@comunica/actor-query-operation-path-link" "^4.0.2"
-    "@comunica/actor-query-operation-path-nps" "^4.0.2"
-    "@comunica/actor-query-operation-path-one-or-more" "^4.0.2"
-    "@comunica/actor-query-operation-path-seq" "^4.0.2"
-    "@comunica/actor-query-operation-path-zero-or-more" "^4.0.2"
-    "@comunica/actor-query-operation-path-zero-or-one" "^4.0.2"
-    "@comunica/actor-query-operation-project" "^4.0.2"
-    "@comunica/actor-query-operation-reduced-hash" "^4.0.2"
-    "@comunica/actor-query-operation-service" "^4.0.2"
-    "@comunica/actor-query-operation-slice" "^4.0.2"
-    "@comunica/actor-query-operation-source" "^4.0.2"
-    "@comunica/actor-query-operation-union" "^4.0.2"
-    "@comunica/actor-query-operation-update-clear" "^4.0.2"
-    "@comunica/actor-query-operation-update-compositeupdate" "^4.0.2"
-    "@comunica/actor-query-operation-update-create" "^4.0.2"
-    "@comunica/actor-query-operation-update-deleteinsert" "^4.0.2"
-    "@comunica/actor-query-operation-update-drop" "^4.0.2"
-    "@comunica/actor-query-operation-update-load" "^4.0.2"
-    "@comunica/actor-query-operation-values" "^4.0.2"
-    "@comunica/actor-query-parse-graphql" "^4.0.2"
-    "@comunica/actor-query-parse-sparql" "^4.0.2"
-    "@comunica/actor-query-process-explain-logical" "^4.0.2"
-    "@comunica/actor-query-process-explain-parsed" "^4.0.2"
-    "@comunica/actor-query-process-explain-physical" "^4.0.2"
-    "@comunica/actor-query-process-sequential" "^4.0.2"
-    "@comunica/actor-query-result-serialize-json" "^4.0.2"
-    "@comunica/actor-query-result-serialize-rdf" "^4.0.2"
-    "@comunica/actor-query-result-serialize-simple" "^4.0.2"
-    "@comunica/actor-query-result-serialize-sparql-csv" "^4.0.2"
-    "@comunica/actor-query-result-serialize-sparql-json" "^4.0.2"
-    "@comunica/actor-query-result-serialize-sparql-tsv" "^4.0.2"
-    "@comunica/actor-query-result-serialize-sparql-xml" "^4.0.2"
-    "@comunica/actor-query-result-serialize-stats" "^4.0.2"
-    "@comunica/actor-query-result-serialize-table" "^4.0.2"
-    "@comunica/actor-query-result-serialize-tree" "^4.0.2"
-    "@comunica/actor-query-source-identify-hypermedia" "^4.0.2"
-    "@comunica/actor-query-source-identify-hypermedia-none" "^4.0.2"
-    "@comunica/actor-query-source-identify-hypermedia-qpf" "^4.0.2"
-    "@comunica/actor-query-source-identify-hypermedia-sparql" "^4.0.2"
-    "@comunica/actor-query-source-identify-rdfjs" "^4.0.2"
-    "@comunica/actor-query-source-identify-serialized" "^4.0.2"
-    "@comunica/actor-rdf-join-entries-sort-cardinality" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-hash" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-multi-bind" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-multi-bind-source" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-multi-empty" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-multi-smallest" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-nestedloop" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-none" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-single" "^4.0.2"
-    "@comunica/actor-rdf-join-inner-symmetrichash" "^4.0.2"
-    "@comunica/actor-rdf-join-minus-hash" "^4.0.2"
-    "@comunica/actor-rdf-join-optional-bind" "^4.0.2"
-    "@comunica/actor-rdf-join-optional-hash" "^4.0.2"
-    "@comunica/actor-rdf-join-optional-nestedloop" "^4.0.2"
-    "@comunica/actor-rdf-join-selectivity-variable-counting" "^4.0.2"
-    "@comunica/actor-rdf-metadata-accumulate-cardinality" "^4.0.2"
-    "@comunica/actor-rdf-metadata-accumulate-pagesize" "^4.0.2"
-    "@comunica/actor-rdf-metadata-accumulate-requesttime" "^4.0.2"
-    "@comunica/actor-rdf-metadata-all" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-allow-http-methods" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-hydra-count" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-hydra-pagesize" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-patch-sparql-update" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-put-accepted" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-request-time" "^4.0.2"
-    "@comunica/actor-rdf-metadata-extract-sparql-service" "^4.0.2"
-    "@comunica/actor-rdf-metadata-primary-topic" "^4.0.2"
-    "@comunica/actor-rdf-parse-html" "^4.0.2"
-    "@comunica/actor-rdf-parse-html-microdata" "^4.0.2"
-    "@comunica/actor-rdf-parse-html-rdfa" "^4.0.2"
-    "@comunica/actor-rdf-parse-html-script" "^4.0.2"
-    "@comunica/actor-rdf-parse-jsonld" "^4.0.2"
-    "@comunica/actor-rdf-parse-n3" "^4.0.2"
-    "@comunica/actor-rdf-parse-rdfxml" "^4.0.2"
-    "@comunica/actor-rdf-parse-shaclc" "^4.0.2"
-    "@comunica/actor-rdf-parse-xml-rdfa" "^4.0.2"
-    "@comunica/actor-rdf-resolve-hypermedia-links-next" "^4.0.2"
-    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo" "^4.0.2"
-    "@comunica/actor-rdf-serialize-jsonld" "^4.0.2"
-    "@comunica/actor-rdf-serialize-n3" "^4.0.2"
-    "@comunica/actor-rdf-serialize-shaclc" "^4.0.2"
-    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update" "^4.0.2"
-    "@comunica/actor-rdf-update-hypermedia-put-ldp" "^4.0.2"
-    "@comunica/actor-rdf-update-hypermedia-sparql" "^4.0.2"
-    "@comunica/actor-rdf-update-quads-hypermedia" "^4.0.2"
-    "@comunica/actor-rdf-update-quads-rdfjs-store" "^4.0.2"
-    "@comunica/actor-term-comparator-factory-expression-evaluator" "^4.0.2"
-    "@comunica/bus-function-factory" "^4.0.2"
-    "@comunica/bus-http-invalidate" "^4.0.2"
-    "@comunica/bus-query-operation" "^4.0.2"
-    "@comunica/config-query-sparql" "^4.0.1"
-    "@comunica/core" "^4.0.2"
-    "@comunica/logger-void" "^4.0.2"
-    "@comunica/mediator-all" "^4.0.2"
-    "@comunica/mediator-combine-pipeline" "^4.0.2"
-    "@comunica/mediator-combine-union" "^4.0.2"
-    "@comunica/mediator-join-coefficients-fixed" "^4.0.2"
-    "@comunica/mediator-number" "^4.0.2"
-    "@comunica/mediator-race" "^4.0.2"
-    "@comunica/runner" "^4.0.2"
-    "@comunica/runner-cli" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+
+"@comunica/query-sparql@^5.0.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/query-sparql/-/query-sparql-5.3.0.tgz#7de6ab5dee2622dd46184c1c36799ddf0d1b8ff2"
+  integrity sha512-sRr3ZOp5ksqUMvFW8XL56lpnzNt0XH4p+3fSXNqIGo6UfMDl5MeZVwDCwQ/TxQI0kHIZzOtPZ4QVv8+j2SnZPQ==
+  dependencies:
+    "@comunica/actor-bindings-aggregator-factory-average" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-count" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-group-concat" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-max" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-min" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-sample" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-sum" "^5.3.0"
+    "@comunica/actor-bindings-aggregator-factory-wildcard-count" "^5.3.0"
+    "@comunica/actor-context-preprocess-convert-shortcuts" "^5.3.0"
+    "@comunica/actor-context-preprocess-set-defaults" "^5.3.0"
+    "@comunica/actor-context-preprocess-source-to-destination" "^5.3.0"
+    "@comunica/actor-dereference-fallback" "^5.3.0"
+    "@comunica/actor-dereference-http" "^5.3.0"
+    "@comunica/actor-dereference-rdf-parse" "^5.3.0"
+    "@comunica/actor-expression-evaluator-factory-default" "^5.3.0"
+    "@comunica/actor-function-factory-expression-bnode" "^5.3.0"
+    "@comunica/actor-function-factory-expression-bound" "^5.3.0"
+    "@comunica/actor-function-factory-expression-coalesce" "^5.3.0"
+    "@comunica/actor-function-factory-expression-concat" "^5.3.0"
+    "@comunica/actor-function-factory-expression-extensions" "^5.3.0"
+    "@comunica/actor-function-factory-expression-if" "^5.3.0"
+    "@comunica/actor-function-factory-expression-in" "^5.3.0"
+    "@comunica/actor-function-factory-expression-logical-and" "^5.3.0"
+    "@comunica/actor-function-factory-expression-logical-or" "^5.3.0"
+    "@comunica/actor-function-factory-expression-not-in" "^5.3.0"
+    "@comunica/actor-function-factory-expression-same-term" "^5.3.0"
+    "@comunica/actor-function-factory-term-abs" "^5.3.0"
+    "@comunica/actor-function-factory-term-addition" "^5.3.0"
+    "@comunica/actor-function-factory-term-ceil" "^5.3.0"
+    "@comunica/actor-function-factory-term-contains" "^5.3.0"
+    "@comunica/actor-function-factory-term-datatype" "^5.3.0"
+    "@comunica/actor-function-factory-term-day" "^5.3.0"
+    "@comunica/actor-function-factory-term-division" "^5.3.0"
+    "@comunica/actor-function-factory-term-encode-for-uri" "^5.3.0"
+    "@comunica/actor-function-factory-term-equality" "^5.3.0"
+    "@comunica/actor-function-factory-term-floor" "^5.3.0"
+    "@comunica/actor-function-factory-term-greater-than" "^5.3.0"
+    "@comunica/actor-function-factory-term-greater-than-equal" "^5.3.0"
+    "@comunica/actor-function-factory-term-has-lang" "^5.3.0"
+    "@comunica/actor-function-factory-term-has-langdir" "^5.3.0"
+    "@comunica/actor-function-factory-term-hours" "^5.3.0"
+    "@comunica/actor-function-factory-term-inequality" "^5.3.0"
+    "@comunica/actor-function-factory-term-iri" "^5.3.0"
+    "@comunica/actor-function-factory-term-is-blank" "^5.3.0"
+    "@comunica/actor-function-factory-term-is-iri" "^5.3.0"
+    "@comunica/actor-function-factory-term-is-literal" "^5.3.0"
+    "@comunica/actor-function-factory-term-is-numeric" "^5.3.0"
+    "@comunica/actor-function-factory-term-is-triple" "^5.3.0"
+    "@comunica/actor-function-factory-term-lang" "^5.3.0"
+    "@comunica/actor-function-factory-term-langdir" "^5.3.0"
+    "@comunica/actor-function-factory-term-langmatches" "^5.3.0"
+    "@comunica/actor-function-factory-term-lcase" "^5.3.0"
+    "@comunica/actor-function-factory-term-lesser-than" "^5.3.0"
+    "@comunica/actor-function-factory-term-lesser-than-equal" "^5.3.0"
+    "@comunica/actor-function-factory-term-md5" "^5.3.0"
+    "@comunica/actor-function-factory-term-minutes" "^5.3.0"
+    "@comunica/actor-function-factory-term-month" "^5.3.0"
+    "@comunica/actor-function-factory-term-multiplication" "^5.3.0"
+    "@comunica/actor-function-factory-term-not" "^5.3.0"
+    "@comunica/actor-function-factory-term-now" "^5.3.0"
+    "@comunica/actor-function-factory-term-object" "^5.3.0"
+    "@comunica/actor-function-factory-term-predicate" "^5.3.0"
+    "@comunica/actor-function-factory-term-rand" "^5.3.0"
+    "@comunica/actor-function-factory-term-regex" "^5.3.0"
+    "@comunica/actor-function-factory-term-replace" "^5.3.0"
+    "@comunica/actor-function-factory-term-round" "^5.3.0"
+    "@comunica/actor-function-factory-term-seconds" "^5.3.0"
+    "@comunica/actor-function-factory-term-sha1" "^5.3.0"
+    "@comunica/actor-function-factory-term-sha256" "^5.3.0"
+    "@comunica/actor-function-factory-term-sha384" "^5.3.0"
+    "@comunica/actor-function-factory-term-sha512" "^5.3.0"
+    "@comunica/actor-function-factory-term-str" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-after" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-before" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-dt" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-ends" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-lang" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-langdir" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-len" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-starts" "^5.3.0"
+    "@comunica/actor-function-factory-term-str-uuid" "^5.3.0"
+    "@comunica/actor-function-factory-term-sub-str" "^5.3.0"
+    "@comunica/actor-function-factory-term-subject" "^5.3.0"
+    "@comunica/actor-function-factory-term-subtraction" "^5.3.0"
+    "@comunica/actor-function-factory-term-timezone" "^5.3.0"
+    "@comunica/actor-function-factory-term-triple" "^5.3.0"
+    "@comunica/actor-function-factory-term-tz" "^5.3.0"
+    "@comunica/actor-function-factory-term-ucase" "^5.3.0"
+    "@comunica/actor-function-factory-term-unary-minus" "^5.3.0"
+    "@comunica/actor-function-factory-term-unary-plus" "^5.3.0"
+    "@comunica/actor-function-factory-term-uuid" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-boolean" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-date" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-datetime" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-day-time-duration" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-decimal" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-double" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-duration" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-float" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-integer" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-string" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-time" "^5.3.0"
+    "@comunica/actor-function-factory-term-xsd-to-year-month-duration" "^5.3.0"
+    "@comunica/actor-function-factory-term-year" "^5.3.0"
+    "@comunica/actor-hash-bindings-murmur" "^5.3.0"
+    "@comunica/actor-hash-quads-murmur" "^5.3.0"
+    "@comunica/actor-http-fetch" "^5.3.0"
+    "@comunica/actor-http-limit-rate" "^5.3.0"
+    "@comunica/actor-http-proxy" "^5.3.0"
+    "@comunica/actor-http-retry" "^5.3.0"
+    "@comunica/actor-http-retry-body" "^5.3.0"
+    "@comunica/actor-http-wayback" "^5.3.0"
+    "@comunica/actor-init-query" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-assign-sources-exhaustive" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-bgp-to-join" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-construct-distinct" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-describe-to-constructs-subject" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-distinct-terms-pushdown" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-filter-pushdown" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-group-file-sources" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-group-sources" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-join-bgp" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-join-connected" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-leftjoin-expression-pushdown" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-prune-empty-source-operations" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-query-source-identify" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-query-source-skolemize" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-rewrite-add" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-rewrite-copy" "^5.3.0"
+    "@comunica/actor-optimize-query-operation-rewrite-move" "^5.3.0"
+    "@comunica/actor-query-operation-ask" "^5.3.0"
+    "@comunica/actor-query-operation-bgp-join" "^5.3.0"
+    "@comunica/actor-query-operation-construct" "^5.3.0"
+    "@comunica/actor-query-operation-distinct-identity" "^5.3.0"
+    "@comunica/actor-query-operation-extend" "^5.3.0"
+    "@comunica/actor-query-operation-filter" "^5.3.0"
+    "@comunica/actor-query-operation-from-quad" "^5.3.0"
+    "@comunica/actor-query-operation-group" "^5.3.0"
+    "@comunica/actor-query-operation-join" "^5.3.0"
+    "@comunica/actor-query-operation-leftjoin" "^5.3.0"
+    "@comunica/actor-query-operation-minus" "^5.3.0"
+    "@comunica/actor-query-operation-nodes" "^5.3.0"
+    "@comunica/actor-query-operation-nop" "^5.3.0"
+    "@comunica/actor-query-operation-orderby" "^5.3.0"
+    "@comunica/actor-query-operation-path-alt" "^5.3.0"
+    "@comunica/actor-query-operation-path-inv" "^5.3.0"
+    "@comunica/actor-query-operation-path-link" "^5.3.0"
+    "@comunica/actor-query-operation-path-nps" "^5.3.0"
+    "@comunica/actor-query-operation-path-one-or-more" "^5.3.0"
+    "@comunica/actor-query-operation-path-seq" "^5.3.0"
+    "@comunica/actor-query-operation-path-zero-or-more" "^5.3.0"
+    "@comunica/actor-query-operation-path-zero-or-one" "^5.3.0"
+    "@comunica/actor-query-operation-project" "^5.3.0"
+    "@comunica/actor-query-operation-reduced-hash" "^5.3.0"
+    "@comunica/actor-query-operation-slice" "^5.3.0"
+    "@comunica/actor-query-operation-source" "^5.3.0"
+    "@comunica/actor-query-operation-union" "^5.3.0"
+    "@comunica/actor-query-operation-update-clear" "^5.3.0"
+    "@comunica/actor-query-operation-update-compositeupdate" "^5.3.0"
+    "@comunica/actor-query-operation-update-create" "^5.3.0"
+    "@comunica/actor-query-operation-update-deleteinsert" "^5.3.0"
+    "@comunica/actor-query-operation-update-drop" "^5.3.0"
+    "@comunica/actor-query-operation-update-load" "^5.3.0"
+    "@comunica/actor-query-operation-values" "^5.3.0"
+    "@comunica/actor-query-parse-graphql" "^5.3.0"
+    "@comunica/actor-query-parse-sparql" "^5.3.0"
+    "@comunica/actor-query-process-explain-logical" "^5.3.0"
+    "@comunica/actor-query-process-explain-parsed" "^5.3.0"
+    "@comunica/actor-query-process-explain-physical" "^5.3.0"
+    "@comunica/actor-query-process-explain-query" "^5.3.0"
+    "@comunica/actor-query-process-sequential" "^5.3.0"
+    "@comunica/actor-query-result-serialize-json" "^5.3.0"
+    "@comunica/actor-query-result-serialize-rdf" "^5.3.0"
+    "@comunica/actor-query-result-serialize-simple" "^5.3.0"
+    "@comunica/actor-query-result-serialize-sparql-csv" "^5.3.0"
+    "@comunica/actor-query-result-serialize-sparql-json" "^5.3.0"
+    "@comunica/actor-query-result-serialize-sparql-tsv" "^5.3.0"
+    "@comunica/actor-query-result-serialize-sparql-xml" "^5.3.0"
+    "@comunica/actor-query-result-serialize-stats" "^5.3.0"
+    "@comunica/actor-query-result-serialize-table" "^5.3.0"
+    "@comunica/actor-query-result-serialize-tree" "^5.3.0"
+    "@comunica/actor-query-serialize-sparql" "^5.3.0"
+    "@comunica/actor-query-source-dereference-link-force-sparql" "^5.3.0"
+    "@comunica/actor-query-source-dereference-link-hypermedia" "^5.3.0"
+    "@comunica/actor-query-source-identify-compositefile" "^5.3.0"
+    "@comunica/actor-query-source-identify-hypermedia" "^5.3.0"
+    "@comunica/actor-query-source-identify-hypermedia-none" "^5.3.0"
+    "@comunica/actor-query-source-identify-hypermedia-qpf" "^5.3.0"
+    "@comunica/actor-query-source-identify-hypermedia-sparql" "^5.3.0"
+    "@comunica/actor-query-source-identify-rdfjs" "^5.3.0"
+    "@comunica/actor-query-source-identify-serialized" "^5.3.0"
+    "@comunica/actor-rdf-join-entries-sort-cardinality" "^5.3.0"
+    "@comunica/actor-rdf-join-entries-sort-selectivity" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-hash" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-multi-bind" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-multi-bind-source" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-multi-empty" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-multi-smallest" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-multi-smallest-filter-bindings" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-nestedloop" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-none" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-single" "^5.3.0"
+    "@comunica/actor-rdf-join-inner-symmetrichash" "^5.3.0"
+    "@comunica/actor-rdf-join-minus-hash" "^5.3.0"
+    "@comunica/actor-rdf-join-optional-bind" "^5.3.0"
+    "@comunica/actor-rdf-join-optional-hash" "^5.3.0"
+    "@comunica/actor-rdf-join-optional-nestedloop" "^5.3.0"
+    "@comunica/actor-rdf-join-selectivity-variable-counting" "^5.3.0"
+    "@comunica/actor-rdf-metadata-accumulate-cardinality" "^5.3.0"
+    "@comunica/actor-rdf-metadata-accumulate-pagesize" "^5.3.0"
+    "@comunica/actor-rdf-metadata-accumulate-requesttime" "^5.3.0"
+    "@comunica/actor-rdf-metadata-all" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-allow-http-methods" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-hydra-controls" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-hydra-count" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-hydra-pagesize" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-patch-sparql-update" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-post-accepted" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-put-accepted" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-request-time" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-server-software" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-sparql-service" "^5.3.0"
+    "@comunica/actor-rdf-metadata-extract-void" "^5.3.0"
+    "@comunica/actor-rdf-metadata-primary-topic" "^5.3.0"
+    "@comunica/actor-rdf-parse-html" "^5.3.0"
+    "@comunica/actor-rdf-parse-html-microdata" "^5.3.0"
+    "@comunica/actor-rdf-parse-html-rdfa" "^5.3.0"
+    "@comunica/actor-rdf-parse-html-script" "^5.3.0"
+    "@comunica/actor-rdf-parse-jsonld" "^5.3.0"
+    "@comunica/actor-rdf-parse-n3" "^5.3.0"
+    "@comunica/actor-rdf-parse-rdfxml" "^5.3.0"
+    "@comunica/actor-rdf-parse-shaclc" "^5.3.0"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^5.3.0"
+    "@comunica/actor-rdf-resolve-hypermedia-links-next" "^5.3.0"
+    "@comunica/actor-rdf-resolve-hypermedia-links-queue-fifo" "^5.3.0"
+    "@comunica/actor-rdf-serialize-jsonld" "^5.3.0"
+    "@comunica/actor-rdf-serialize-n3" "^5.3.0"
+    "@comunica/actor-rdf-serialize-shaclc" "^5.3.0"
+    "@comunica/actor-rdf-update-hypermedia-patch-sparql-update" "^5.3.0"
+    "@comunica/actor-rdf-update-hypermedia-put-ldp" "^5.3.0"
+    "@comunica/actor-rdf-update-hypermedia-sparql" "^5.3.0"
+    "@comunica/actor-rdf-update-quads-hypermedia" "^5.3.0"
+    "@comunica/actor-rdf-update-quads-rdfjs-store" "^5.3.0"
+    "@comunica/actor-term-comparator-factory-expression-evaluator" "^5.3.0"
+    "@comunica/bus-function-factory" "^5.3.0"
+    "@comunica/bus-http-invalidate" "^5.3.0"
+    "@comunica/bus-query-operation" "^5.3.0"
+    "@comunica/config-query-sparql" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/logger-void" "^5.3.0"
+    "@comunica/mediator-all" "^5.3.0"
+    "@comunica/mediator-combine-pipeline" "^5.3.0"
+    "@comunica/mediator-combine-union" "^5.3.0"
+    "@comunica/mediator-join-coefficients-fixed" "^5.3.0"
+    "@comunica/mediator-number" "^5.3.0"
+    "@comunica/mediator-race" "^5.3.0"
+    "@comunica/runner" "^5.3.0"
+    "@comunica/runner-cli" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     process "^0.11.10"
 
-"@comunica/runner-cli@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/runner-cli/-/runner-cli-4.0.2.tgz#7facc83a32199b2e044940c663131f521b0f8688"
-  integrity sha512-rQxbPMr9nZ40Mr6hKEkGnKJvTYZLm8h/bceg5xGg7Ad5BTpRVXCE43HE3TKQsX0gswxztOHrkmiLdu7EGkq44A==
+"@comunica/runner-cli@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/runner-cli/-/runner-cli-5.3.0.tgz#978f8e528ac050d03c92cb1430e30bc93f80874b"
+  integrity sha512-nZRhOR8cWcp/WpOz2XvNSS0LKhuAueUrBVU0p5PnUElO3tSSTdx8XSWD+zvQ5MJ+AnMA+3nWgQcoGelINu/ilw==
   dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/runner" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/core" "^5.3.0"
+    "@comunica/runner" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     process "^0.11.10"
 
-"@comunica/runner@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-4.0.2.tgz#9c1042b4ccf8be10f62b881edc0cf75dda1fa02b"
-  integrity sha512-NMB9Fgh9z0PJbd2DZxMB9IEIrZFERG7oOEUrGHDhYvOWcuwAc1ra2S/aqgqphANiwFNLco3uqwahKQgNp65Pog==
+"@comunica/runner@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/runner/-/runner-5.3.0.tgz#7201cb4a67ca56819fd4f3a1fdeddef2b2714d6a"
+  integrity sha512-RjbneWhBfD0TYQbDQ6hEfjAJQe2HhF7eVEA3CwJd8zHHMSUaypijK2ptERIi75prL5llN8Rvod9i/B4eYQ6FRA==
   dependencies:
-    "@comunica/bus-init" "^4.0.2"
-    "@comunica/core" "^4.0.2"
+    "@comunica/bus-init" "^5.3.0"
+    "@comunica/core" "^5.3.0"
     componentsjs "^6.2.0"
     process "^0.11.10"
 
@@ -3966,75 +4440,97 @@
     lru-cache "^10.0.1"
     sparqlalgebrajs "^4.3.8"
 
-"@comunica/utils-bindings-factory@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-bindings-factory/-/utils-bindings-factory-4.0.2.tgz#2b6e3f3765d6b28fa6c97e980fa2e1faeb7e2857"
-  integrity sha512-6Di4xYUFbA58+QmFX/prN1akQsgDzCiaHvVqECIkNX48QpAbIUWzCUkinsOY8N8OMqv1s8Rrl32/jhmBbKKcFg==
+"@comunica/types@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-5.3.0.tgz#07241304424483086a98c5881238f6e93d8b623d"
+  integrity sha512-kuEX8uPzCgkVFQRFBrIA7ZYYkiWmQ3BhLlhii9GL3PfbquU0V2QOsebcP21l3rOSNBV63G3IQiWFdhk1Lql2pw==
   dependencies:
-    "@comunica/bus-merge-bindings-context" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/utils-algebra" "^5.3.0"
     "@rdfjs/types" "*"
-    immutable "^4.1.0"
-    rdf-string "^1.6.1"
+    "@types/yargs" "^17.0.24"
+    asynciterator "^3.10.0"
+    lru-cache "^11.2.2"
 
-"@comunica/utils-bindings-index@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-bindings-index/-/utils-bindings-index-4.0.2.tgz#29adce611d575597d954daa363c9daffcf597742"
-  integrity sha512-7cxgCUbojFTN0SNzaUIwntrJIhLV75S8x7q7sbHJvLC7eNbk1G9/GsrmCDeH7Z5hKUTvdTHN1PjYwGF0K4wevw==
-  dependencies:
-    "@comunica/types" "^4.0.2"
-    "@rdfjs/types" "*"
-
-"@comunica/utils-data-factory@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-data-factory/-/utils-data-factory-4.0.1.tgz#ea0ce2b24d05d26718df4e218233ef2bfdeebd0f"
-  integrity sha512-6FTyTC0dNgXwnZN4/5QSDsfNT7AhWPJUcE3a9aa78kQodaq3LfQNW4fiG4tC2O4tcbSy4Ds7ZG/cflThCHwa2w==
+"@comunica/utils-algebra@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-algebra/-/utils-algebra-5.3.0.tgz#ba68b75eb903d12bcd432f70ebb6a27184034c23"
+  integrity sha512-P/2qjAtuI/wk5RXDkrJuGlgwrRYh+vtl45ZzADs1YEeklzNM4AWT1Fbl501qnwi4MApr6xwPK6OxoQQ+ergB7g==
   dependencies:
     "@rdfjs/types" "*"
+    "@traqula/algebra-transformations-1-2" "^1.1.7"
+    "@traqula/core" "^1.1.4"
+    rdf-terms "^2.0.0"
 
-"@comunica/utils-expression-evaluator@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-4.0.2.tgz#8852ba8123fa93d72bfc23cc2266c39752ba88ec"
-  integrity sha512-yHrRypC+OPApSYnfIwkgEAl/hyHaNWfptDimmEQoDQjpjY64L4ocF5Y1NNeX0XAPx2/s7QFaRJ1ATYsZEMPLsA==
+"@comunica/utils-bindings-factory@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-bindings-factory/-/utils-bindings-factory-5.3.0.tgz#bee0a89ab86d71d7fa8b9aeb415e7dcf8f071ff9"
+  integrity sha512-CFlQAMKg00a42S/bFKFNUUCyECXPhcqApV/VFcbh4lNWZ0y/9SqQ4Qq/JymH9R3DigshFjEgBCxQ0AIOzBV8Jw==
   dependencies:
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
+    "@comunica/bus-merge-bindings-context" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    lru-cache "^10.0.0"
-    rdf-data-factory "^1.1.2"
-    rdf-string "^1.6.3"
-    sparqlalgebrajs "^4.3.8"
+    immutable "^5.1.3"
+    rdf-string "^2.0.1"
 
-"@comunica/utils-iterator@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-iterator/-/utils-iterator-4.0.1.tgz#bab9016a479fc5891afd40bdb78702291352af06"
-  integrity sha512-JfWFr212IFpRIe0kU//AdtrPgcKusnRnHeipqVKv6EVeWl3ZfPZsO/e+aSr/llQoAJBaGKfMH0ATuXzWCSjU/g==
+"@comunica/utils-bindings-index@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-bindings-index/-/utils-bindings-index-5.3.0.tgz#685871b3ddd1f3744e8223e1a00ebbae1ebbe22e"
+  integrity sha512-8k36woPeAEkSU/kcUvs9mgYIi7dawfPH9+si/nQlfST3NegUK8TPE0qAnzFQV/uvqDSg5+Cpo2cfl4/h0C4jWQ==
   dependencies:
-    asynciterator "^3.9.0"
-
-"@comunica/utils-metadata@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-metadata/-/utils-metadata-4.0.2.tgz#fbc7a902649b4932cb5accc10c800c845f858490"
-  integrity sha512-Fe/BcuEfDH4GYD4z2M5TOBp3JUjWLPb/vIchOnw70ycRY6AsFNK8IVOVsgD4uV0yz2scHSxZhJjMzQOdb0tMqQ==
-  dependencies:
-    "@comunica/types" "^4.0.2"
+    "@comunica/types" "^5.3.0"
     "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
 
-"@comunica/utils-query-operation@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/utils-query-operation/-/utils-query-operation-4.0.2.tgz#b34c5788f0060d805eda668bb77351522ef010fc"
-  integrity sha512-dEyCIWQ3lA6sDiWNkatw6vQ2QnVXfQol50/EfjkVzf2bdSJSVLDRECY6VGkwpdrEBkCZaABAPif134oDSYv8SQ==
+"@comunica/utils-data-factory@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-data-factory/-/utils-data-factory-5.0.0.tgz#0f2716c4cb2e2eeecb043679ef026210b8b7d2ce"
+  integrity sha512-F5nkZjDSDdydAItS19svrWdWdCTx7pLCGlVomePa1IiF117TOZZMyI9bcFmh9SoIpmoitfMPHre3Fhm8DSd0uQ==
   dependencies:
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@comunica/utils-bindings-factory" "^4.0.2"
     "@rdfjs/types" "*"
-    rdf-string "^1.6.1"
-    rdf-terms "^1.11.0"
-    sparqlalgebrajs "^4.3.8"
+
+"@comunica/utils-expression-evaluator@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-expression-evaluator/-/utils-expression-evaluator-5.3.0.tgz#9cdc710d391067890da80d5b63ea9628247d54b1"
+  integrity sha512-moaI6ZA5G62dvxUzTjiw9xqoc+EKopIgSp/a+aBVu95gqj02zm0rHWVOAdgCLyu19l58uMK7MCR6hwDbLnbsDQ==
+  dependencies:
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@rdfjs/types" "*"
+    lru-cache "^11.2.2"
+    rdf-data-factory "^2.0.0"
+    rdf-string "^2.0.1"
+
+"@comunica/utils-iterator@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-iterator/-/utils-iterator-5.0.0.tgz#759f6e9398617c69eac40c78e2c3220964293bfc"
+  integrity sha512-iognyhJ4kkwZe2zZTB9MbELiUKypVGWjLFSY+xnVqu7WjDAAkmj2KuD9jRKXdYsvMT43CUo7JXh+2vIxYGL68Q==
+  dependencies:
+    asynciterator "^3.10.0"
+
+"@comunica/utils-metadata@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-metadata/-/utils-metadata-5.3.0.tgz#99c555991ecd423a233405c3904bd593e7c56ef2"
+  integrity sha512-4INJurpISwJQ37YjguK2+usOs5nLVbD3/cXiKE2Kc44QKMdX3ykySjmNvZRd3VSfd5G50ML8KtHeCZUR5C8CbQ==
+  dependencies:
+    "@comunica/types" "^5.3.0"
+    "@rdfjs/types" "*"
+    asynciterator "^3.10.0"
+
+"@comunica/utils-query-operation@^5.3.0":
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/@comunica/utils-query-operation/-/utils-query-operation-5.3.0.tgz#3162a72de23a6935d34bd1aff8eb411edef4f8f7"
+  integrity sha512-gmqfXoo1G7UMKemyOYgp6yF8KEqb/PLiWX2MlRB8+YniswjotGSJ/IBY/24UEW6GnHqNMSQsNQ8LjKa5UxzrGw==
+  dependencies:
+    "@comunica/context-entries" "^5.3.0"
+    "@comunica/core" "^5.3.0"
+    "@comunica/types" "^5.3.0"
+    "@comunica/utils-algebra" "^5.3.0"
+    "@comunica/utils-bindings-factory" "^5.3.0"
+    "@rdfjs/types" "*"
+    rdf-data-factory "^2.0.0"
+    rdf-string "^2.0.1"
+    rdf-terms "^2.0.0"
 
 "@dabh/diagnostics@^2.0.2":
   version "2.0.3"
@@ -4687,6 +5183,111 @@
     "@stylistic/eslint-plugin-ts" "1.8.1"
     "@types/eslint" "^8.56.10"
 
+"@traqula/algebra-sparql-1-1@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/algebra-sparql-1-1/-/algebra-sparql-1-1-1.2.0.tgz#f3a382e0472f3654fd3a80075176e16895313459"
+  integrity sha512-+0CH9csrlAvq6rLiW+t3eBp6ELFYANM96wrM3Afwh2c+yZm41TOGHQKqA17r+PHCDm7TCJKgSzJvVEuesCHe6Q==
+  dependencies:
+    "@traqula/algebra-transformations-1-1" "^1.2.0"
+    "@traqula/core" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+
+"@traqula/algebra-sparql-1-2@^1.0.0", "@traqula/algebra-sparql-1-2@^1.1.7":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/algebra-sparql-1-2/-/algebra-sparql-1-2-1.2.0.tgz#00c4ebd9bab98e344605250dbb18af52f32ee02f"
+  integrity sha512-dFZqnPUYlQpao9XeIjjtxV6ye9PNrPxfw7chmX9DzqqA6CWuklaVrmn2DftOUG7IzcvyvUxeXf5EYZ4S4KUz9Q==
+  dependencies:
+    "@traqula/algebra-sparql-1-1" "^1.2.0"
+    "@traqula/algebra-transformations-1-1" "^1.2.0"
+    "@traqula/algebra-transformations-1-2" "^1.2.0"
+    "@traqula/core" "^1.2.0"
+
+"@traqula/algebra-transformations-1-1@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/algebra-transformations-1-1/-/algebra-transformations-1-1-1.2.0.tgz#6cc8f0ed0040cf5139910e97513c97268562ffb9"
+  integrity sha512-lVztghs5wDL2KCVLqpxFlA2v9amexMjnh+rkrGTWgOqC3x/qZC9w6MoEpd/eLjZ9ShW7PK9pB3h2ZImBVnfXPQ==
+  dependencies:
+    "@traqula/core" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+    fast-deep-equal "^3.1.3"
+    rdf-data-factory "^2.0.1"
+    rdf-isomorphic "^2.0.0"
+    rdf-string "^2.0.0"
+
+"@traqula/algebra-transformations-1-2@^1.0.0", "@traqula/algebra-transformations-1-2@^1.1.7", "@traqula/algebra-transformations-1-2@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/algebra-transformations-1-2/-/algebra-transformations-1-2-1.2.0.tgz#31f9bc21115071e5775498701be77ff379899771"
+  integrity sha512-bTGh8oQbdPYBPHyMVjTj81Xs9Wf7oWLp9dqCPhEzD4MAgXn32UVF2mjUXJiD2pC9avZzo6Dn2Y6//s9VPX9f3Q==
+  dependencies:
+    "@traqula/algebra-transformations-1-1" "^1.2.0"
+    "@traqula/rules-sparql-1-2" "^1.2.0"
+    rdf-string "^2.0.0"
+
+"@traqula/chevrotain@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@traqula/chevrotain/-/chevrotain-1.1.0.tgz#1ebd234481e63091eeed3f2d5cca8de7f3990044"
+  integrity sha512-VpcoQKb2ZnsOQPlPO2mE9hfR0Aidp7drwTCtaXfpdRHGkXeQ5Nv4rnxmxwUoEDRzu6b/3z4n8oTd+sYhe4fAaA==
+
+"@traqula/core@^1.1.4", "@traqula/core@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/core/-/core-1.2.0.tgz#ec1f24817bc832da0bc95c2ef0e8090337c2edbc"
+  integrity sha512-4NEYjNKD31u1DMbccRNXBnpEQsoeVrTTrJfxbDU11/5zHQdcyrXYlJ7Dq2t3hlZgStMbVJrZbZJsr6p+lZBeZA==
+  dependencies:
+    "@traqula/chevrotain" "^1.1.0"
+
+"@traqula/generator-sparql-1-1@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/generator-sparql-1-1/-/generator-sparql-1-1-1.2.0.tgz#5aea51dee57199622b8201b2988fb2fbf50c0aa3"
+  integrity sha512-n83fb2Geo7sb1dwhI+3XaNr4NCndh8LsGqpdrXvBtIkFRAbFK5aL+L92Sd6L81hHmQ7JDOlJfiHJhUVXEQ0U5A==
+  dependencies:
+    "@traqula/core" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+
+"@traqula/generator-sparql-1-2@^1.0.0", "@traqula/generator-sparql-1-2@^1.1.6":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/generator-sparql-1-2/-/generator-sparql-1-2-1.2.0.tgz#ed0401800e3ee5fb58f51f995426a94222cb4732"
+  integrity sha512-owyk5ZNsKVncQD+S8M45mvBdKg/7G5T3ucf5LU64+gp/WmWLnPs7fh7XG4FWlo10L/RcD6yBpNiUGn3Bb6DkyQ==
+  dependencies:
+    "@traqula/core" "^1.2.0"
+    "@traqula/generator-sparql-1-1" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+    "@traqula/rules-sparql-1-2" "^1.2.0"
+
+"@traqula/parser-sparql-1-1@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/parser-sparql-1-1/-/parser-sparql-1-1-1.2.0.tgz#6098f22b1fde75aec6e115947ad2c66d26e66210"
+  integrity sha512-UsBEV03dxSfmiUYupvr2DJInGdnkgUCPBYbdp9IWgsbP43rIguhbllTHGwzzgYeuAtMd2SnhMc5kB93Asm/VuQ==
+  dependencies:
+    "@traqula/core" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+
+"@traqula/parser-sparql-1-2@^1.0.0", "@traqula/parser-sparql-1-2@^1.1.6":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/parser-sparql-1-2/-/parser-sparql-1-2-1.2.0.tgz#c437665e93631154496331b8356a310ec2e286d7"
+  integrity sha512-13wAa4k78e2ZOzMSTyI0vs9Mj3of3267pMmeY7NtstVLQkQVXYuzR9JF08U8Dbq8dezZHBEFZwUtpQd5MqYhhg==
+  dependencies:
+    "@traqula/core" "^1.2.0"
+    "@traqula/parser-sparql-1-1" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+    "@traqula/rules-sparql-1-2" "^1.2.0"
+    rdf-data-factory "^2.0.1"
+
+"@traqula/rules-sparql-1-1@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/rules-sparql-1-1/-/rules-sparql-1-1-1.2.0.tgz#7ceabf0dd474b41acff8164a0f2dea43695c89c6"
+  integrity sha512-akf/+UOVrurX9NREnupQfCyYj4seg305nmNuIcJJ6QN/V2ikb1WGwcUeS2iMELtY3MsRdb4A13xbY4GtblCYmQ==
+  dependencies:
+    "@traqula/chevrotain" "^1.1.0"
+    "@traqula/core" "^1.2.0"
+
+"@traqula/rules-sparql-1-2@^1.0.0", "@traqula/rules-sparql-1-2@^1.1.6", "@traqula/rules-sparql-1-2@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@traqula/rules-sparql-1-2/-/rules-sparql-1-2-1.2.0.tgz#0d239b06b11aa45654f12fa0b0f9b55127add2ae"
+  integrity sha512-4NwxRSZnlxwoDuJmuMl+2ebZbEZEnZxkA5WI06o9NVRTLPn1BiWl/lxNVMI03Jx48xyFyuui0qifVqD0sU3UBQ==
+  dependencies:
+    "@traqula/core" "^1.2.0"
+    "@traqula/rules-sparql-1-1" "^1.2.0"
+
 "@tybys/wasm-util@^0.10.0":
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
@@ -4739,6 +5340,11 @@
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/http-cache-semantics@^4.0.4":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#f6a7788f438cbfde15f29acad46512b4c01913b3"
+  integrity sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==
 
 "@types/http-link-header@^1.0.1":
   version "1.0.7"
@@ -4806,7 +5412,7 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.5.tgz#ec10755e871497bcd83efe927e43ec46e8c0747e"
   integrity sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==
 
-"@types/n3@^1.0.0", "@types/n3@^1.10.3", "@types/n3@^1.10.4":
+"@types/n3@^1.0.0", "@types/n3@^1.10.3":
   version "1.21.1"
   resolved "https://registry.yarnpkg.com/@types/n3/-/n3-1.21.1.tgz#5e9f93f50e7a77f8c40bffa3e66f67209633c235"
   integrity sha512-9KxFlFj3etnpdI2nyQEp/jHry5DHxWT22z9Nc/y/hdHe0CHVc9rKu+NacWKUyN06dDLDh7ZnjCzY8yBJ9lmzdw==
@@ -4848,10 +5454,17 @@
     "@types/node" "*"
     safe-buffer "~5.1.1"
 
-"@types/readable-stream@^4.0.0", "@types/readable-stream@^4.0.15":
+"@types/readable-stream@^4.0.0":
   version "4.0.23"
   resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-4.0.23.tgz#fcd0f7472f45ceb43154f08f0083ccd1c76e53ce"
   integrity sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==
+  dependencies:
+    "@types/node" "*"
+
+"@types/readable-stream@^4.0.18":
+  version "4.0.24"
+  resolved "https://registry.yarnpkg.com/@types/readable-stream/-/readable-stream-4.0.24.tgz#7b2431bfc1367d05c53598ad36094b044726d442"
+  integrity sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==
   dependencies:
     "@types/node" "*"
 
@@ -4877,7 +5490,7 @@
   resolved "https://registry.yarnpkg.com/@types/spark-md5/-/spark-md5-3.0.5.tgz#eddec8639217e518c26e9e221ff56bf5f5f5c900"
   integrity sha512-lWf05dnD42DLVKQJZrDHtWFidcLrHuip01CtnC2/S6AMhX4t9ZlEUj4iuRlAnts0PQk7KESOqKxeGE/b6sIPGg==
 
-"@types/sparqljs@^3.0.0", "@types/sparqljs@^3.1.3":
+"@types/sparqljs@^3.1.3":
   version "3.1.12"
   resolved "https://registry.yarnpkg.com/@types/sparqljs/-/sparqljs-3.1.12.tgz#29a030615a3aed6eb05fbd618ecf58ab345506f8"
   integrity sha512-zg/sdKKtYI0845wKPSuSgunyU1o/+7tRzMw85lHsf4p/0UbA6+65MXAyEtv1nkaqSqrq/bXm7+bqXas+Xo5dpQ==
@@ -4904,10 +5517,10 @@
   resolved "https://registry.yarnpkg.com/@types/uritemplate/-/uritemplate-0.3.6.tgz#1eb0e8075ece916869d88c9542824c91db80703e"
   integrity sha512-31BMGZ8GgLxgXxLnqg4KbbyYJjU1flhTTD2+PVQStVUPXSk0IIpK0zt+tH3eLT7ZRwLnzQw6JhYx69qza3U0wg==
 
-"@types/uuid@^9.0.0":
-  version "9.0.8"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.8.tgz#7545ba4fc3c003d6c756f651f3bf163d8f0f29ba"
-  integrity sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==
+"@types/uuid@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
+  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
 
 "@types/yargs-parser@*":
   version "21.0.3"
@@ -5431,6 +6044,13 @@ async@^3.2.3:
   resolved "https://registry.yarnpkg.com/async/-/async-3.2.6.tgz#1b0728e14929d51b85b449b7f06e27c1145e38ce"
   integrity sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==
 
+asynciterator@^3.10.0:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.10.0.tgz#b9baade3792078235dbb6b35f6d28e88db76c5ce"
+  integrity sha512-eDOBoUf2m+4ht0ETVn2SCfuBIZZ6UWyyQbP++LRPKoK7PmrCQq37pJ6vRvyef4o1Pn+CwWnzMlkXxGdh/krVIw==
+  dependencies:
+    tiny-set-immediate "^1.0.2"
+
 asynciterator@^3.8.0, asynciterator@^3.8.1, asynciterator@^3.9.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/asynciterator/-/asynciterator-3.9.0.tgz#6e9a69623c4cec07e4cd85130416d52899f4e93f"
@@ -5552,10 +6172,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-bignumber.js@^9.1.2:
-  version "9.1.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-9.1.2.tgz#b7c4242259c008903b13707983b5f4bbd31eda0c"
-  integrity sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==
+bignumber.js@^11.0.0:
+  version "11.1.5"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-11.1.5.tgz#0f678769f989e6947138d16adaaaa475a9b0bc65"
+  integrity sha512-6WmzCNtUnfKpbozq+hOgWaZMMzORmYBwF1xZScyoIX3QRYWeKTtxxwDOW5tIz7C9BdjkIYHGTcelCLkXg0mndw==
 
 boolbase@^1.0.0:
   version "1.0.0"
@@ -6156,7 +6776,7 @@ domhandler@^5.0.2, domhandler@^5.0.3:
   dependencies:
     domelementtype "^2.3.0"
 
-domutils@^3.0.1, domutils@^3.1.0:
+domutils@^3.0.1, domutils@^3.1.0, domutils@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
@@ -6228,6 +6848,11 @@ entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -6967,22 +7592,21 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.3.tgz#4d9ccdbc61e8629b259fdca67e65891448d569fd"
   integrity sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==
 
-fetch-sparql-endpoint@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-5.1.0.tgz#95000b48aca1cb601ebd345af24ddbcd173d665c"
-  integrity sha512-ylROBEdVOVzaGdngq3hSGuA/cDtmRiMmPMU75dsu9xatdKEtU39vRp3HbVxdgzqDDX4HU0FnTBQ/+ciMaEBdbA==
+fetch-sparql-endpoint@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fetch-sparql-endpoint/-/fetch-sparql-endpoint-7.1.1.tgz#f912fcc6bb9b2c8ec67497fb667a46fcacaa2e25"
+  integrity sha512-OslECjEPhhTg2uXJpuKqucOFLkIaK2TkbUjW+fWgHKLsH4kTZ/J7UKid2w6f3dF0MOEqF0gEO5kiUh3pq3uhfA==
   dependencies:
-    "@rdfjs/types" "*"
+    "@traqula/parser-sparql-1-2" "^1.0.0"
+    "@traqula/rules-sparql-1-2" "^1.0.0"
     "@types/n3" "^1.0.0"
     "@types/readable-stream" "^4.0.0"
-    "@types/sparqljs" "^3.0.0"
     is-stream "^2.0.0"
-    n3 "^1.0.0"
-    rdf-string "^1.0.0"
+    n3 "^2.0.0"
+    rdf-string "^2.0.0"
     readable-from-web "^1.0.0"
-    sparqljs "^3.0.0"
-    sparqljson-parse "^2.0.0"
-    sparqlxml-parse "^2.0.0"
+    sparqljson-parse "^3.3.0"
+    sparqlxml-parse "^3.3.0"
     stream-to-string "^1.0.0"
     yargs "^17.0.0"
 
@@ -7319,22 +7943,23 @@ graphemer@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphemer/-/graphemer-1.4.0.tgz#fb2f1d55e0e3a1849aeffc90c4fa0dd53a0e66c6"
   integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
-graphql-to-sparql@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/graphql-to-sparql/-/graphql-to-sparql-4.0.0.tgz#1b61ebb6084e7665cce90fd13155f1b6fb73ea5f"
-  integrity sha512-H/wIQFdqvNf6CQs84/+eEb5O/w51HsRv1+XPl6d1nJxLqflYAg9yf6D4a46uqUCw/pxiY5E4JjwyBRdMOgtKsw==
+graphql-to-sparql@^6.0.0:
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/graphql-to-sparql/-/graphql-to-sparql-6.1.0.tgz#72e77f296b259bd0269a3a64e1ab7916de3407f7"
+  integrity sha512-AEHBVxnyTc5BzY3S5bIpIdOU6mHspn031ZsJ0+sdIeEcVwicr3tLZ77K0uzTNTD6ID35XZonp3mQRyfzhwVjQA==
   dependencies:
-    "@rdfjs/types" "*"
-    graphql "^15.5.2"
+    "@traqula/algebra-sparql-1-2" "^1.0.0"
+    "@traqula/algebra-transformations-1-2" "^1.0.0"
+    "@traqula/generator-sparql-1-2" "^1.0.0"
+    graphql "^17.0.0"
     jsonld-context-parser "^3.0.0"
     minimist "^1.2.0"
-    rdf-data-factory "^1.1.0"
-    sparqlalgebrajs "^4.0.0"
+    rdf-data-factory "^2.0.1"
 
-graphql@^15.5.2:
-  version "15.9.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.9.0.tgz#4e8ca830cfd30b03d44d3edd9cac2b0690304b53"
-  integrity sha512-GCOQdvm7XxV1S4U4CGrsdlEN37245eC8P9zaYCMr6K1BG0IPGy5lUwmJsEOGyl1GD6HXjOtl2keCP9asRBwNvA==
+graphql@^17.0.0:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-17.0.2.tgz#05ff6f18e0801e8d040d46957eba712c1459d5d7"
+  integrity sha512-FRWbddMxfkjiB7z+aQDWIR+E34xo9I8c9mtK2RPv8PmMzKRvrdsreHL/Ui/TmwHJfhHChEtsFPyMHKI+xuarQQ==
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -7422,6 +8047,16 @@ html-escaper@^2.0.0:
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
+htmlparser2@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
 htmlparser2@^8.0.0:
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-8.0.2.tgz#f002151705b383e62433b5cf466f5b716edaec21"
@@ -7441,6 +8076,11 @@ htmlparser2@^9.0.0:
     domhandler "^5.0.3"
     domutils "^3.1.0"
     entities "^4.5.0"
+
+http-cache-semantics@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
+  integrity sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==
 
 http-link-header@^1.0.2:
   version "1.1.3"
@@ -7475,6 +8115,11 @@ immutable@^4.1.0, immutable@^4.3.7:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
   integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
+
+immutable@^5.1.3:
+  version "5.1.9"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-5.1.9.tgz#ac23c3a01992ab665e14ac9ffff298f28cd74a0c"
+  integrity sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==
 
 import-fresh@^3.2.1:
   version "3.3.1"
@@ -8444,12 +9089,12 @@ jsonld-streaming-parser@^5.0.0:
     rdf-data-factory "^2.0.0"
     readable-stream "^4.0.0"
 
-jsonld-streaming-serializer@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-3.0.1.tgz#42c4e748060924586d71b0f80800c0f05e613a63"
-  integrity sha512-lw5Z785Km53DRZ0ngyEamC3ojGdjFRDKvUt3b7lW5e8sqmTc7GHZxFBBw7IIqbb0Wc2WNksoXewmF13FC9bPNg==
+jsonld-streaming-serializer@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/jsonld-streaming-serializer/-/jsonld-streaming-serializer-4.0.0.tgz#43144323ab099ccbeb0b840bd4c81a2591c01f23"
+  integrity sha512-YUg5Er7CSWB6+ZiHreBUoBILEttowto/fT654W5a+6iIiAI65Jz023Wtsi/XUCLUkItDWYe6ckYUbCV1aSQbtA==
   dependencies:
-    "@rdfjs/types" "*"
+    "@rdfjs/types" "^2.0.0"
     "@types/readable-stream" "^4.0.0"
     buffer "^6.0.3"
     jsonld-context-parser "^3.0.0"
@@ -8594,7 +9239,7 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lru-cache@^10.0.0, lru-cache@^10.0.1, lru-cache@^10.2.0:
+lru-cache@^10.0.1, lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -8603,6 +9248,11 @@ lru-cache@^11.0.0:
   version "11.2.7"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.2.7.tgz#9127402617f34cd6767b96daee98c28e74458d35"
   integrity sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==
+
+lru-cache@^11.2.2:
+  version "11.5.2"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-11.5.2.tgz#00e16665c90c620fba14a3c368732a976493f760"
+  integrity sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==
 
 lru-cache@^5.1.1:
   version "5.1.1"
@@ -8714,6 +9364,16 @@ microdata-rdf-streaming-parser@^2.0.1:
     "@rdfjs/types" "*"
     htmlparser2 "^8.0.0"
     rdf-data-factory "^1.1.0"
+    readable-stream "^4.1.0"
+    relative-to-absolute-iri "^1.0.2"
+
+microdata-rdf-streaming-parser@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/microdata-rdf-streaming-parser/-/microdata-rdf-streaming-parser-3.0.0.tgz#ca26eefb49bfc412e646b81f7bf61cff29a63f18"
+  integrity sha512-CgdDaKqKAc/4gVhzUX7b1H0dKtnydqNu7dCMcvUceCZpAxX/6EO9w/U1Po195/F9fZY/oQakEREz8U1X7yrhAQ==
+  dependencies:
+    htmlparser2 "^9.0.0"
+    rdf-data-factory "^2.0.0"
     readable-stream "^4.1.0"
     relative-to-absolute-iri "^1.0.2"
 
@@ -8836,13 +9496,21 @@ ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-n3@^1.0.0, n3@^1.16.3, n3@^1.17.0:
+n3@^1.16.3, n3@^1.17.0:
   version "1.23.1"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.23.1.tgz#42a5aded4802db7a3c5d22feec19bdd919190268"
   integrity sha512-3f0IYJo+6+lXypothmlwPzm3wJNffsxUwnfONeFv2QqWq7RjTvyCMtkRXDUXW6XrZoOzaQX8xTTSYNlGjXcGtw==
   dependencies:
     buffer "^6.0.3"
     queue-microtask "^1.1.2"
+    readable-stream "^4.0.0"
+
+n3@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-2.2.0.tgz#f133281b28d0e8ff6ba9d7fdd0cbcfd291807a82"
+  integrity sha512-K/Orb5XrUPocfYfhUT+muvK1I0n2AvVMt93fIExlgjo23u7q0lU0eIFrhBJqooyFWAnpEBz3QZqjHzEHMs1RZg==
+  dependencies:
+    buffer "^6.0.3"
     readable-stream "^4.0.0"
 
 n3@^2.0.3:
@@ -9352,7 +10020,7 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.1, rdf-data-factory@^1.1.2:
+rdf-data-factory@^1.0.1, rdf-data-factory@^1.1.0, rdf-data-factory@^1.1.2:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz#11b39e0c80e51bca83828b2ddaa686f733be966f"
   integrity sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==
@@ -9363,6 +10031,13 @@ rdf-data-factory@^2.0.0, rdf-data-factory@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-2.0.1.tgz#d45895e5b3a7e940a01deade5dee9b313f979134"
   integrity sha512-qpCmbtuCjdH5I2vnn+RpdAcWr32RKOv0ATKM4A2Df+d4yRk1YWiBnAY/S6ndxxY90bb5Ig9458I6Tlytozu5eg==
+  dependencies:
+    "@rdfjs/types" "^2.0.0"
+
+rdf-data-factory@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz#dfac1fdf99502f3b6d61f8e99e97af2490346e32"
+  integrity sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==
   dependencies:
     "@rdfjs/types" "^2.0.0"
 
@@ -9501,45 +10176,22 @@ rdf-quad@^2.0.0:
     rdf-literal "^2.0.0"
     rdf-string "^2.0.0"
 
-rdf-store-stream@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-2.0.1.tgz#f61ab958e11876f763fdc3799eff58589f998181"
-  integrity sha512-znGaibHLvbRE0BrDcXHRleRcLKlHYP6ADr1RFJ3yA28QBmhOjxxgbBFTvCMzgsxvBIqdaFS8Vd2FG4NefJL4Mg==
+rdf-store-stream@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-store-stream/-/rdf-store-stream-3.0.0.tgz#79ec49161f6f76c429ef88065f26b1f3e1e5bd74"
+  integrity sha512-y30MHEyEnS1SjMzPhioZRvZ9yz4e6FL96TFq6YcMCUSDvT8zONotAfz28kMbOUAcKCncmrCJiukjP7Q1bJT4aw==
   dependencies:
-    "@rdfjs/types" "*"
-    rdf-stores "^1.0.0"
+    rdf-stores "^2.0.0"
 
-rdf-stores@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rdf-stores/-/rdf-stores-1.0.0.tgz#1689bd669853bda857620d0db32f3b59940db208"
-  integrity sha512-wqp7M5409rbhpWQE0C1vyVysbz++aD2vEkZ6yueSxhDtyLvznS41R3cKiuUpm3ikc/yTpaCZwPo4iyKEaAwBIg==
+rdf-stores@^2.0.0, rdf-stores@^2.2.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/rdf-stores/-/rdf-stores-2.3.0.tgz#49ac3340cfcb4f06dedcfe3ab06ea12c9c091bf0"
+  integrity sha512-KfXy5sBDKdpJUx1KOquzx72smxu9tkMbhIr/lEUEte6ZWjGTW40/sWXlfVwblhy0kHKzu3z4cMRyiHO9sWAORw==
   dependencies:
-    "@rdfjs/types" "*"
     asynciterator "^3.8.0"
-    rdf-data-factory "^1.1.1"
-    rdf-string "^1.6.2"
-    rdf-terms "^1.9.1"
-
-rdf-streaming-store@^1.1.4:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/rdf-streaming-store/-/rdf-streaming-store-1.1.5.tgz#64f1cbb570ebdd532b9f3e7742d62f106e97cb5b"
-  integrity sha512-Rfd3qo1otF/Jfau/lAFX8J1ZPorN0eaHoIkAlenIIcdZjq9AoIP85rEa4Sn+yMZOqNU1Kc4cCPUv5CFHhpAT2Q==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/n3" "^1.10.4"
-    "@types/readable-stream" "^4.0.15"
-    n3 "^1.16.3"
-    rdf-string "^1.6.2"
-    rdf-terms "^1.9.1"
-    readable-stream "^4.3.0"
-
-rdf-string-ttl@^1.3.2:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/rdf-string-ttl/-/rdf-string-ttl-1.3.2.tgz#56060c41680a1ed46cf99d3b42a65754e037dd35"
-  integrity sha512-yqolaVoUvTaSC5aaQuMcB4BL54G/pCGsV4jQH87f0TvAx8zHZG0koh7XWrjva/IPGcVb1QTtaeEdfda5mcddJg==
-  dependencies:
-    "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.0"
+    rdf-data-factory "^2.0.1"
+    rdf-string "^2.0.0"
+    rdf-terms "^2.0.0"
 
 rdf-string-ttl@^2.0.1:
   version "2.0.1"
@@ -9548,7 +10200,7 @@ rdf-string-ttl@^2.0.1:
   dependencies:
     rdf-data-factory "^2.0.0"
 
-rdf-string@^1.0.0, rdf-string@^1.5.0, rdf-string@^1.6.0, rdf-string@^1.6.1, rdf-string@^1.6.2, rdf-string@^1.6.3:
+rdf-string@^1.5.0, rdf-string@^1.6.0:
   version "1.6.3"
   resolved "https://registry.yarnpkg.com/rdf-string/-/rdf-string-1.6.3.tgz#5c3173fad13e6328698277fb8ff151e3423282ab"
   integrity sha512-HIVwQ2gOqf+ObsCLSUAGFZMIl3rh9uGcRf1KbM85UDhKqP+hy6qj7Vz8FKt3GA54RiThqK3mNcr66dm1LP0+6g==
@@ -9563,7 +10215,7 @@ rdf-string@^2.0.0, rdf-string@^2.0.1:
   dependencies:
     rdf-data-factory "^2.0.0"
 
-rdf-terms@^1.10.0, rdf-terms@^1.11.0, rdf-terms@^1.7.0, rdf-terms@^1.9.1:
+rdf-terms@^1.10.0, rdf-terms@^1.7.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/rdf-terms/-/rdf-terms-1.11.0.tgz#0c2e3a2b43f1042959c9263af27dab08dc4b084d"
   integrity sha512-iKlVgnMopRKl9pHVNrQrax7PtZKRCT/uJIgYqvuw1VVQb88zDvurtDr1xp0rt7N9JtKtFwUXoIQoEsjyRo20qQ==
@@ -9591,6 +10243,16 @@ rdfa-streaming-parser@^2.0.1:
     readable-stream "^4.0.0"
     relative-to-absolute-iri "^1.0.2"
 
+rdfa-streaming-parser@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rdfa-streaming-parser/-/rdfa-streaming-parser-3.0.2.tgz#069a3cfb11618a8728e3142b1dbda25fbe3db42d"
+  integrity sha512-1MEkALT5PYjucVo6lNHXd9DbkgW0hSfPOJOs/TpUFe9zoZvkoreKcGIFnMFkbMmYTNLCiGFo/74LviIUnWLkIw==
+  dependencies:
+    htmlparser2 "^9.0.0"
+    rdf-data-factory "^2.0.0"
+    readable-stream "^4.0.0"
+    relative-to-absolute-iri "^1.0.2"
+
 rdfxml-streaming-parser@^2.2.3:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.4.0.tgz#6552d5c5b448739d52a97e18126dfcdf0d84c877"
@@ -9614,6 +10276,19 @@ rdfxml-streaming-parser@^3.0.0:
     "@types/readable-stream" "^2.3.13"
     buffer "^6.0.3"
     rdf-data-factory "^2.0.0"
+    readable-stream "^4.4.2"
+    relative-to-absolute-iri "^1.0.0"
+    validate-iri "^1.0.0"
+
+rdfxml-streaming-parser@^3.2.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.3.0.tgz#6473b79ff6957435d865d25ba50bcb2bd77dbbd0"
+  integrity sha512-ym3RO0T4K4NOF23BpsvrNyhIdevuZvY/1kYV5gQJ6z3s0m6Ui9ZH1QZIA/VyNEWHG0x1nTg1QzN/0i4KMVk3EA==
+  dependencies:
+    "@rubensworks/saxes" "^6.0.1"
+    "@types/readable-stream" "^4.0.18"
+    buffer "^6.0.3"
+    rdf-data-factory "^2.0.2"
     readable-stream "^4.4.2"
     relative-to-absolute-iri "^1.0.0"
     validate-iri "^1.0.0"
@@ -9669,7 +10344,7 @@ readable-stream@3, readable-stream@^3.0.0, readable-stream@^3.4.0, readable-stre
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
 
-readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.2.0, readable-stream@^4.3.0, readable-stream@^4.4.2, readable-stream@^4.5.1, readable-stream@^4.5.2, readable-stream@^4.7.0:
+readable-stream@^4.0.0, readable-stream@^4.1.0, readable-stream@^4.3.0, readable-stream@^4.4.2, readable-stream@^4.5.1, readable-stream@^4.5.2, readable-stream@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-4.7.0.tgz#cedbd8a1146c13dfff8dab14068028d58c15ac91"
   integrity sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==
@@ -9977,14 +10652,22 @@ shaclc-parse@^1.4.0:
     "@rdfjs/types" "^1.1.0"
     n3 "^1.16.3"
 
-shaclc-write@^1.4.2:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.4.3.tgz#c6833f642d6b72f0119f1511f62ccc545e79007d"
-  integrity sha512-dtJ6LokIluzQuHRWCFvNnmGyh07FxBK2L4utkOQn/wYD9eNamUUCt7sDBcuFDyD3jAGv0Ipmv0EitTyKcM1f/w==
+shaclc-parse@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-2.0.0.tgz#326fa50202bb5bc104c9bd10e55a9016f21431e9"
+  integrity sha512-YEznPru7QmcIR1lF/lCvvrrcjZ8vWfKBMAketPb2CRWkrA0LUffTzrW0tOepue/evUREkJyl8LeVpcmyyKF+ng==
+  dependencies:
+    "@rdfjs/types" "^2.0.0"
+    n3 "^2.0.0"
+
+shaclc-write@^1.6.0:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/shaclc-write/-/shaclc-write-1.6.3.tgz#a15942e9c11795bc64573e35ed3ee3872cf3f6ce"
+  integrity sha512-R6rHiDov9kppjXTTaSwuaOUC3JXhJWvlrxR++Eng1jNdtD3oywkAagRu6mS5rzTcMA4WBxLUXdJxu4CbPOG04A==
   dependencies:
     "@jeswr/prefixcc" "^1.2.1"
-    n3 "^1.16.3"
-    rdf-string-ttl "^1.3.2"
+    n3 "^2.0.0"
+    rdf-string-ttl "^2.0.1"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -10088,7 +10771,7 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.2.0, sparqlalgebrajs@^4.3.7, sparqlalgebrajs@^4.3.8:
+sparqlalgebrajs@^4.2.0, sparqlalgebrajs@^4.3.8:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.3.8.tgz#2b339120fc3e4d7cc952c113ee6f1ab8e0d3b7a5"
   integrity sha512-Xo1/5icRtVk2N38BrY9NXN8N/ZPjULlns7sDHv0nlcGOsOediBLWVy8LmV+Q90RHvb3atZZbrFy3VqrM4iXciA==
@@ -10103,7 +10786,7 @@ sparqlalgebrajs@^4.0.0, sparqlalgebrajs@^4.2.0, sparqlalgebrajs@^4.3.7, sparqlal
     rdf-terms "^1.10.0"
     sparqljs "^3.7.1"
 
-sparqljs@^3.0.0, sparqljs@^3.7.1:
+sparqljs@^3.7.1:
   version "3.7.3"
   resolved "https://registry.yarnpkg.com/sparqljs/-/sparqljs-3.7.3.tgz#075821d51ef4954284e36569503fe5558cfb71b0"
   integrity sha512-FQfHUhfwn5PD9WH6xPU7DhFfXMgqK/XoDrYDVxz/grhw66Il0OjRg3JBgwuEvwHnQt7oSTiKWEiCZCPNaUbqgg==
@@ -10131,6 +10814,16 @@ sparqljson-parse@^3.0.0:
     rdf-data-factory "^2.0.0"
     readable-stream "^4.0.0"
 
+sparqljson-parse@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/sparqljson-parse/-/sparqljson-parse-3.3.0.tgz#d6770a1f3fd4fd2e168c2cc7027eaaa72051a31c"
+  integrity sha512-XrmkCsrx4n69Ak63Ju7t91hVlWw7YhEPPdA+giW2GRTosQxPur0JWh7rQin/8aT0WjKZgBgGpsNnVBYyyWUq1w==
+  dependencies:
+    "@bergos/jsonparse" "^1.4.1"
+    "@types/readable-stream" "^4.0.0"
+    rdf-data-factory "^2.0.0"
+    readable-stream "^4.0.0"
+
 sparqljson-to-tree@^3.0.1:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/sparqljson-to-tree/-/sparqljson-to-tree-3.0.2.tgz#94d0fd1c019715aea8bb459cdf8951f41e2f4a63"
@@ -10140,22 +10833,21 @@ sparqljson-to-tree@^3.0.1:
     rdf-literal "^1.3.2"
     sparqljson-parse "^2.0.0"
 
-sparqlxml-parse@^2.0.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-2.1.1.tgz#594a3bf8893bb29062cf1be4b0809937741b22f4"
-  integrity sha512-71sltShF6gDAzuKWEHNeij7r0Mv5VqRrvJing6W4WHJ12GRe6+t1IRTv6MeqxYN3XJmKevs7B3HCBUo7wceeJQ==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@rubensworks/saxes" "^6.0.1"
-    "@types/readable-stream" "^2.3.13"
-    buffer "^6.0.3"
-    rdf-data-factory "^1.1.0"
-    readable-stream "^4.0.0"
-
 sparqlxml-parse@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-3.0.0.tgz#2a88f37625c3eb71e5617a0a6f9eabff8a28cf58"
   integrity sha512-d52hvNNCf6obLXQUIyB64ffm7d/xX0C7IfzUQWXtpW1iKACh+V1ZMS+q+zSOlY7TWW3fLhaPHFvINwt2g9LM9A==
+  dependencies:
+    "@rubensworks/saxes" "^6.0.1"
+    "@types/readable-stream" "^4.0.0"
+    buffer "^6.0.3"
+    rdf-data-factory "^2.0.0"
+    readable-stream "^4.5.2"
+
+sparqlxml-parse@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/sparqlxml-parse/-/sparqlxml-parse-3.3.0.tgz#829d01c2ca38e92180fe20957a192d6d0d797c81"
+  integrity sha512-FUVgcUr2YePDtDuu/UcMTF2ODiKBQdZdcfTSvaR3QhWVAcBmIGX4r4apsePK1zCc1kkRR53JBHXHJho/Pk538g==
   dependencies:
     "@rubensworks/saxes" "^6.0.1"
     "@types/readable-stream" "^4.0.0"
@@ -10492,6 +11184,11 @@ through2@^4.0.0:
   dependencies:
     readable-stream "3"
 
+tiny-set-immediate@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-set-immediate/-/tiny-set-immediate-1.0.2.tgz#4abcc1cd597e9cdcd6515c3c0a18c8ef4d98f292"
+  integrity sha512-EVbaM4zXFWS4CIqVoPzY7XIioQ5LU1p49AHizwPO1KyFyp/gxy5SA8mDmfDVl/2WLQiHgUL+esO6Ig+KhpUxUw==
+
 tinyglobby@^0.2.13:
   version "0.2.16"
   resolved "https://registry.yarnpkg.com/tinyglobby/-/tinyglobby-0.2.16.tgz#1c3b7eb953fce42b226bc5a1ee06428281aff3d6"
@@ -10723,6 +11420,11 @@ undici-types@~6.20.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
   integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
+undici@^8.0.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-8.10.0.tgz#67ed7c4087f0f40fba7bef3a46f2be80572f2473"
+  integrity sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==
+
 unist-util-stringify-position@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-2.0.3.tgz#cce3bfa1cdf85ba7375d1d5b17bdc4cada9bd9da"
@@ -10790,15 +11492,15 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
+uuid@^11.0.0:
+  version "11.1.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
+  integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==
+
 uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^9.0.0:
-  version "9.0.1"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
-  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 v8-to-istanbul@^9.0.1:
   version "9.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -496,14 +496,6 @@
     "@comunica/core" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/actor-abstract-mediatyped@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-4.0.2.tgz#1850698d7f2ea525d28f64bc0b890884117a0880"
-  integrity sha512-WN14hyPi0d2vpRnHd3JgVZm/6OlgG2Hn2q3cxOHYXNYBGVXE2g+1wlWe6WPW8HsGz3waO2rj0VKIXo0UsCPm6w==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
 "@comunica/actor-abstract-mediatyped@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-mediatyped/-/actor-abstract-mediatyped-5.3.0.tgz#fa319eb8c14479848a7db590be822528e2a37735"
@@ -519,14 +511,6 @@
   dependencies:
     "@comunica/core" "^2.10.0"
     readable-stream "^4.4.2"
-
-"@comunica/actor-abstract-parse@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-abstract-parse/-/actor-abstract-parse-4.0.2.tgz#ffed7c530757e45ef207ee17bcb439f0b290ee21"
-  integrity sha512-S3Paqni2rn5pLHg6D42dWlD0EMLHLXtCzhTNvxRoTLxjCW3L5F7HlyrDKmeBOz+Csvzybcw/Qc//+8BlARYCnA==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    readable-stream "^4.5.2"
 
 "@comunica/actor-abstract-parse@^5.3.0":
   version "5.3.0"
@@ -1511,17 +1495,7 @@
     abort-controller "^3.0.0"
     cross-fetch "^4.0.0"
 
-"@comunica/actor-http-fetch@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-4.0.2.tgz#2d79f91bbfb83a28cb69e0c4f8813fd6e5c7d2a3"
-  integrity sha512-otMv4WOWPrTfs4/UTr4tB2BKCIz2r8ncH2pTfQySQpn6KstlxPjWLAKy8ZKVgEg+E7jMTpgm331kwMqUbl2M9g==
-  dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-time" "^4.0.2"
-
-"@comunica/actor-http-fetch@^5.3.0":
+"@comunica/actor-http-fetch@^5.0.0", "@comunica/actor-http-fetch@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-http-fetch/-/actor-http-fetch-5.3.0.tgz#7528608df89cc0af8cbb1cc335e6c179ca717f0f"
   integrity sha512-48ogepU9/BxNHBokUz+0iuKJZ0SCBNSqa/qQ1S0jEm2VtGPhOOCke6ght6Sal4HvG/SgYkZ00U+qjKWDl3NWVA==
@@ -1555,17 +1529,6 @@
     "@comunica/context-entries" "^2.10.0"
     "@comunica/mediatortype-time" "^2.10.0"
     "@comunica/types" "^2.10.0"
-
-"@comunica/actor-http-proxy@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-http-proxy/-/actor-http-proxy-4.0.2.tgz#78e170c3ea7f5aff1862b0df085096adc82b6457"
-  integrity sha512-wIwAXt7kO289u1KIBL2NWY13kMo593weBQKMvP4OFpUHez50/631mMZz8zSLRlsM+KyPhXmPT/RozMFkekojLQ==
-  dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/mediatortype-time" "^4.0.2"
-    "@comunica/types" "^4.0.2"
 
 "@comunica/actor-http-proxy@^5.0.0", "@comunica/actor-http-proxy@^5.3.0":
   version "5.3.0"
@@ -3052,18 +3015,7 @@
     "@comunica/core" "^2.10.0"
     microdata-rdf-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-microdata@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-4.0.2.tgz#b137f5dcfceca891f0726a93140eae02625d7843"
-  integrity sha512-avW0OuD9kCQXwI19vnfZIUVh7PEhs1g90XXHRohwT9lz5hbU4uGZFrUw3owPsV5CwpTBxLMFijBPrk6foN7fog==
-  dependencies:
-    "@comunica/bus-rdf-parse-html" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    microdata-rdf-streaming-parser "^2.0.1"
-
-"@comunica/actor-rdf-parse-html-microdata@^5.3.0":
+"@comunica/actor-rdf-parse-html-microdata@^5.0.0", "@comunica/actor-rdf-parse-html-microdata@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-microdata/-/actor-rdf-parse-html-microdata-5.3.0.tgz#3268d6fe79d9044926a8af74aac66083342122aa"
   integrity sha512-NsKekH1HkWSTDTCJv+ggAvtqA3495FNCquNunfm53uMm86e16JlQBnF50tWMHID/2I3etAh6d+USKNMCGKj1BQ==
@@ -3083,18 +3035,7 @@
     "@comunica/core" "^2.10.0"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-html-rdfa@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-4.0.2.tgz#0e3fa258ec77a2c1f68ac94a00663954881ee895"
-  integrity sha512-OkcV5aJaCLBzNo5/C/MsJvYBCCRFF2WrQyqmoT+w1/vkM4YKYZ7aL87uDKBmB2bTPDUJ6kfLxTV1miQDMI+JuQ==
-  dependencies:
-    "@comunica/bus-rdf-parse-html" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    rdfa-streaming-parser "^2.0.1"
-
-"@comunica/actor-rdf-parse-html-rdfa@^5.3.0":
+"@comunica/actor-rdf-parse-html-rdfa@^5.0.0", "@comunica/actor-rdf-parse-html-rdfa@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-rdfa/-/actor-rdf-parse-html-rdfa-5.3.0.tgz#997eaa0aac72b4c1c02c51c7f3b46f425468822b"
   integrity sha512-lVHir3Pb5Xu+mIwX47lGDf0zedJV+eeUJfdhAJlwpso4ycbZ45B4ZEF5Oq4NsHgcADGi7NmJN1bYP7SJwazP4w==
@@ -3119,21 +3060,7 @@
     readable-stream "^4.4.2"
     relative-to-absolute-iri "^1.0.7"
 
-"@comunica/actor-rdf-parse-html-script@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-4.0.2.tgz#0465c245d7da8d8c6328569406b75f9496f711a7"
-  integrity sha512-oGB52p+ug1YesdnKoonzQxI+yoLKr2j8ds76vdyMw7bJVVl+wSgXzqmwGan2TDmu26WZ/uGK4jQFshtlCiS8RQ==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/bus-rdf-parse-html" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@rdfjs/types" "*"
-    readable-stream "^4.5.2"
-    relative-to-absolute-iri "^1.0.7"
-
-"@comunica/actor-rdf-parse-html-script@^5.3.0":
+"@comunica/actor-rdf-parse-html-script@^5.0.0", "@comunica/actor-rdf-parse-html-script@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html-script/-/actor-rdf-parse-html-script-5.3.0.tgz#59280443a736d97da010b92b177bbaf432e41691"
   integrity sha512-g1pYe5KKhWA3gROxt3J1wIfC1imnm445FP40phxtt8zKdF1s9f8O0aBr6p8zAybiZ3KgBaKRT+OCCbzSQoiapg==
@@ -3160,20 +3087,7 @@
     htmlparser2 "^9.0.0"
     readable-stream "^4.4.2"
 
-"@comunica/actor-rdf-parse-html@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-4.0.2.tgz#4330c864a07a9c2841139d4b4cd391bf952f2a9b"
-  integrity sha512-I10FGPMmwuwUBUi/DZJmAKXqdqb5Ue/oJ8JFifozHdmMZYVcbYCa4AvMQIAKi3qrLeQXciMl7GdA0eb4FQ5/Ag==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/bus-rdf-parse-html" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@rdfjs/types" "*"
-    htmlparser2 "^9.0.0"
-    readable-stream "^4.5.2"
-
-"@comunica/actor-rdf-parse-html@^5.3.0":
+"@comunica/actor-rdf-parse-html@^5.0.0", "@comunica/actor-rdf-parse-html@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-html/-/actor-rdf-parse-html-5.3.0.tgz#3ec0dc1f26204ce42cd2f055fdda346e2143f88d"
   integrity sha512-QM6AobgQ2Gq3ndSa9B20EH3nVribY8LpqEDJfiDwmXBrZpx7p95R0nxlllVZx4beIisZrKSF9FyN00xrhiDQ6g==
@@ -3200,21 +3114,7 @@
     jsonld-streaming-parser "^3.0.1"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-jsonld@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-4.0.2.tgz#ecec4d9c1b79c9823a7ca5c47d7836b2c12172fc"
-  integrity sha512-CpfMvwKOmKf171jlhgztM1WeYDx+VGgODUD1Nq57WkjBPKniHlES6RT5J/4hiPuB8bEyiuX0D65dQLtk32OhAA==
-  dependencies:
-    "@comunica/bus-http" "^4.0.2"
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@jeswr/stream-to-string" "^2.0.0"
-    jsonld-context-parser "^2.2.2"
-    jsonld-streaming-parser "^4.0.1"
-
-"@comunica/actor-rdf-parse-jsonld@^5.3.0":
+"@comunica/actor-rdf-parse-jsonld@^5.0.0", "@comunica/actor-rdf-parse-jsonld@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-5.3.0.tgz#3b0ad1d145d3cb907b6d04f8b979634cf34517a2"
   integrity sha512-bSc8E5nN3H/DnZAi/8AljAbmyv0XuKiQe7tObDKpemhBIKJO1Ch8h/45+Y3ud4NvqJBgu/OEVC4bQL38MnsuBA==
@@ -3239,17 +3139,7 @@
     "@comunica/types" "^2.10.0"
     n3 "^1.17.0"
 
-"@comunica/actor-rdf-parse-n3@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-4.0.2.tgz#21eaf8fbb4eec1047b3f9bd5e5e1aacb9db671db"
-  integrity sha512-9jLntJGaXxUf//qC4J3svwjI7nDpyycIkpAwVCilqKpPhqo+Slji/8hfVQd5YPfuL30jgxqNHAnbo3/ygJcb7Q==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    n3 "^1.17.0"
-
-"@comunica/actor-rdf-parse-n3@^5.3.0":
+"@comunica/actor-rdf-parse-n3@^5.0.0", "@comunica/actor-rdf-parse-n3@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-n3/-/actor-rdf-parse-n3-5.3.0.tgz#fd3c000762984f3144c208760afa202bdbaf2b57"
   integrity sha512-vUqoztMwpqiiHHYhW0KDBWSdd9hcd4gEu7GehwQxiMcmoIBNSJ6UlQQ29Z8rVMr2vmeTCpCgL4q53sKt8MaYTg==
@@ -3268,16 +3158,7 @@
     "@comunica/types" "^2.10.0"
     rdfxml-streaming-parser "^2.2.3"
 
-"@comunica/actor-rdf-parse-rdfxml@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-4.0.2.tgz#f278c4b806a3f8cff0add280959718543af592d5"
-  integrity sha512-7TuUXa6108o1nLWrel4xrZjjHtX82nao6vrbIpn22BaF57S4V09x/xOYO9pZdLn3/i5aZ8Lz9aVF2+NGc4VQzA==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    rdfxml-streaming-parser "^2.2.3"
-
-"@comunica/actor-rdf-parse-rdfxml@^5.3.0":
+"@comunica/actor-rdf-parse-rdfxml@^5.0.0", "@comunica/actor-rdf-parse-rdfxml@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-rdfxml/-/actor-rdf-parse-rdfxml-5.3.0.tgz#a6d3da4b511d22efae41e9c3cd61bad656df5abc"
   integrity sha512-trHmIJ8SGe7hnDZKoyV5mMCZXM0WS2Pg9T+ZmLcZbJPSKIySrhwhSCD83Dc+RW/+oxzYVsj63kh79nScvwZ8wg==
@@ -3299,20 +3180,7 @@
     shaclc-parse "^1.4.0"
     stream-to-string "^1.2.0"
 
-"@comunica/actor-rdf-parse-shaclc@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-4.0.2.tgz#3b657b80236f28bab4d6d018ffd7b0b10a10b786"
-  integrity sha512-DOlz5JbIm5n+SL5hWHjrMud9KpmEsdZT1ybK6OdXI4wZX9NYFeM8QhywgEKUaGhh8gzh2FkcWf5vXfQQfPgGDg==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@jeswr/stream-to-string" "^2.0.0"
-    "@rdfjs/types" "*"
-    asynciterator "^3.9.0"
-    readable-stream "^4.5.2"
-    shaclc-parse "^1.4.0"
-
-"@comunica/actor-rdf-parse-shaclc@^5.3.0":
+"@comunica/actor-rdf-parse-shaclc@^5.0.0", "@comunica/actor-rdf-parse-shaclc@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-shaclc/-/actor-rdf-parse-shaclc-5.3.0.tgz#f5a35c33f3cfa6443e414e20e5b802e52b8e7625"
   integrity sha512-c0qzFd84DAk09WKbEbaI8ynxeunG0csKBO6CVJ5jfje8Qx9MltUNOP4bMWKQma8Y2Oy7pDoXZOjpJAApQyZ8eQ==
@@ -3334,17 +3202,7 @@
     "@comunica/types" "^2.10.0"
     rdfa-streaming-parser "^2.0.1"
 
-"@comunica/actor-rdf-parse-xml-rdfa@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-4.0.2.tgz#0295dea1f5d7091b005a4fe92ca449677f742c0d"
-  integrity sha512-4eRyjMs0SAKI2BgaxLHqvNuRUm0x2uwPTjQr6jO3OqOZTRm8fXsmNfr+/scKRmYANd1OzFEUdcFjAAxYG+pz6g==
-  dependencies:
-    "@comunica/bus-rdf-parse" "^4.0.2"
-    "@comunica/context-entries" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    rdfa-streaming-parser "^2.0.1"
-
-"@comunica/actor-rdf-parse-xml-rdfa@^5.3.0":
+"@comunica/actor-rdf-parse-xml-rdfa@^5.0.0", "@comunica/actor-rdf-parse-xml-rdfa@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/actor-rdf-parse-xml-rdfa/-/actor-rdf-parse-xml-rdfa-5.3.0.tgz#f4222777f0da7f33fa411eb62f1e5bf069dbf2d4"
   integrity sha512-dmtXsCdI1lZ/2zmJD9Tfoj7uUWP+94MIhQkSLB7wqcYQQYQK63dECd98mrI9Ls4NppAukcn3Hg7GqpARdh3XYA==
@@ -3593,18 +3451,7 @@
     readable-stream-node-to-web "^1.0.1"
     web-streams-ponyfill "^1.4.2"
 
-"@comunica/bus-http@^4.0.1", "@comunica/bus-http@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-4.0.2.tgz#1229e9bfe300778a4ee15551463307291577b210"
-  integrity sha512-LCYtkerJ6bN7OnrmLBccQUszZYHYKo4c3prShAD4i+8AGqYecGplEDdueecN5kq4cz0uQjWmqPKIV1mS8NEDWw==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@jeswr/stream-to-string" "^2.0.0"
-    is-stream "^2.0.1"
-    readable-from-web "^1.0.0"
-    readable-stream-node-to-web "^1.0.1"
-
-"@comunica/bus-http@^5.3.0":
+"@comunica/bus-http@^5.0.0", "@comunica/bus-http@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/bus-http/-/bus-http-5.3.0.tgz#5f091cfe461d840a107fc40540e2e282d04bdcb8"
   integrity sha512-/d8FS02Jb5gvFDw21ZiH2Bvt3PRkMN3kkowTRBIArB4wJjt1c7DRXCt2uS7zToNVa0mAdZmKIlC1vpY6g6o3SA==
@@ -3624,15 +3471,7 @@
     "@comunica/core" "^2.10.0"
     readable-stream "^4.4.2"
 
-"@comunica/bus-init@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-4.0.2.tgz#2eb122b434bdf3964183a6199526a68d19601345"
-  integrity sha512-sY0C4ri1oBpiEgAD6s7TF/YG8pQz5sYrnOh93M+QDfKxdJiT7NtxRgkxriGBwB1dH6x7KMymogbbW6jXQccv6g==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    readable-stream "^4.5.2"
-
-"@comunica/bus-init@^5.3.0":
+"@comunica/bus-init@^5.0.0", "@comunica/bus-init@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/bus-init/-/bus-init-5.3.0.tgz#d7c887ea3c04b41dbac8f804b186bb45f6459f06"
   integrity sha512-d0Eyp1MhjTAttzBsglLJd3CLi+D7Z3Beat1a396+qdrqXWNV74TFazKMhymSmwwEUZMeyiIR/YttosOkl1ujkw==
@@ -3802,15 +3641,7 @@
     "@comunica/core" "^2.10.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-parse-html@^4.0.1", "@comunica/bus-rdf-parse-html@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-4.0.2.tgz#f7f3d3ae6648c2e62a7278eccdca55bff51e9336"
-  integrity sha512-PatbiwlgNwMmAFd9UAtzAPrcFhv9PS92UVvyTeML/mNDXCQfUZ9L3bRyQN6DrItYBWTxxCGLkybTSGL4DojwMw==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-rdf-parse-html@^5.3.0":
+"@comunica/bus-rdf-parse-html@^5.0.0", "@comunica/bus-rdf-parse-html@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse-html/-/bus-rdf-parse-html-5.3.0.tgz#e57c4eb8cc3aa853e59466fc765867b1b9518684"
   integrity sha512-P2I8pW/ze2/9b+QQK4cW/j/c4DxAQ7ttto+FTQVwejrgT7doEBWR0niaYEiBOrQo0OirjVbakwbWfGZ57dC0vg==
@@ -3828,17 +3659,7 @@
     "@comunica/core" "^2.10.0"
     "@rdfjs/types" "*"
 
-"@comunica/bus-rdf-parse@^4.0.1", "@comunica/bus-rdf-parse@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-4.0.2.tgz#38b4cdd49b64d860219f5667629e0cc4ab945f56"
-  integrity sha512-ApfN5wTiqwbOkTmT9RNTqX7pTjuS+4mYRqmSUkBUS+4rAf6qcSsfHs+2TB2YtFDy31p7Xw7A1uYYbh+f684d5g==
-  dependencies:
-    "@comunica/actor-abstract-mediatyped" "^4.0.2"
-    "@comunica/actor-abstract-parse" "^4.0.2"
-    "@comunica/core" "^4.0.2"
-    "@rdfjs/types" "*"
-
-"@comunica/bus-rdf-parse@^5.3.0":
+"@comunica/bus-rdf-parse@^5.0.0", "@comunica/bus-rdf-parse@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/bus-rdf-parse/-/bus-rdf-parse-5.3.0.tgz#3f7b2b10a6f39fa4644df230743240a00d630261"
   integrity sha512-t8bRBDUqNAAMB80zpz40gyMhgRcWY72m3TdjT7NxzRzet1QrvHwHSk3OKsnaaoAq1IPooAsW9LWtnl1mGwoY/A==
@@ -3909,12 +3730,7 @@
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-2.7.0.tgz#1030ee76d5532bc6a09a6c8af26a06c7311a5861"
   integrity sha512-rMnFgT7cz9+0z7wV4OzIMY5qM9/Z0mTGrR8y2JokoHyyTcBGOSajFmy61XCSLMCsLLG8qDXsJ4ClCCky3TGfqA==
 
-"@comunica/config-query-sparql@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-4.0.1.tgz#ad7da2b3636aaf7dd3eb5b4918c76ac3bf2c61d7"
-  integrity sha512-jNuRl7PmOKillPfvIzmO+I7IFP0nroFQrZaX/4pUIqe4WNrSCzjZqrLnru0BQtFE5LXcaEA9IdtISSfjwTFt2w==
-
-"@comunica/config-query-sparql@^5.3.0":
+"@comunica/config-query-sparql@^5.0.0", "@comunica/config-query-sparql@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/config-query-sparql/-/config-query-sparql-5.3.0.tgz#4be54d2893a3906ac190a1f6af0f7318d47b75fb"
   integrity sha512-5snTR5p0yjQCIiRrNu6tzNAD1EfahkSNmQUB2AUI04S/lfz97HQ1ycvQroeJ7P08goyBtld2s0AReexUnNhcfw==
@@ -3930,18 +3746,7 @@
     jsonld-context-parser "^2.2.2"
     sparqlalgebrajs "^4.2.0"
 
-"@comunica/context-entries@^4.0.1", "@comunica/context-entries@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-4.0.2.tgz#88396e07f69f924bb015aef782cccd082d17d84e"
-  integrity sha512-ryjSZ/fOyeNgWv1ZISD9BvC052kL8DLffpp/59rEJfbgjv1Phv2Zae7obW05EG8pn1Bk+OspwrkGa4Lps4e6Pg==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-    "@rdfjs/types" "*"
-    jsonld-context-parser "^2.2.2"
-    sparqlalgebrajs "^4.3.8"
-
-"@comunica/context-entries@^5.3.0":
+"@comunica/context-entries@^5.0.0", "@comunica/context-entries@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/context-entries/-/context-entries-5.3.0.tgz#58e9a930ea6f5f2ea0a09fd8d04302aac2eb93e4"
   integrity sha512-B4KXcYgYDrg1HCl1kCyhHM2I/xvyJsSbf8bxHY2xWnaqqytLJPyyMffKdHFRflHc1JmlqpYV6vyc4+5ZBUWzAw==
@@ -3960,15 +3765,7 @@
     "@comunica/types" "^2.10.0"
     immutable "^4.1.0"
 
-"@comunica/core@^4.0.1", "@comunica/core@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/core/-/core-4.0.2.tgz#7a2acfa5ead8b34850734bbb271f67fe499efc3f"
-  integrity sha512-VDh3mejUyqhV2Hf/f43iBWrsAjYfULV+FbF0v/AR1tgESkCS7z949Dzbu8YgkL1CaTX6Ohmqgrhc/yEd9CGZ6Q==
-  dependencies:
-    "@comunica/types" "^4.0.2"
-    immutable "^4.3.7"
-
-"@comunica/core@^5.3.0":
+"@comunica/core@^5.0.0", "@comunica/core@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/core/-/core-5.3.0.tgz#06f3022747762ee43a14f8f5de9aaf9734c21e01"
   integrity sha512-f3TIl78jS/Td4b7jcXm8Ps2aTz70yujgrMn2vYKg6YLcvumA7yVJ5yVvgDz+jhv7wnQfk8yJfnzi2PYwuM4UMw==
@@ -4007,15 +3804,7 @@
     "@comunica/core" "^2.10.0"
     "@comunica/types" "^2.10.0"
 
-"@comunica/mediator-combine-pipeline@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-4.0.2.tgz#dcd3ddfd10fcc81b272bb2304ec67017456dada3"
-  integrity sha512-bU66ZgbP0v7SznZ3SGQXabYsQbUUErrT++WSDfv9w/jm7UJidt8mpRZfPTD0q83Cxu+yfOU5c9ToSVMT93CLGg==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-    "@comunica/types" "^4.0.2"
-
-"@comunica/mediator-combine-pipeline@^5.3.0":
+"@comunica/mediator-combine-pipeline@^5.0.0", "@comunica/mediator-combine-pipeline@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-pipeline/-/mediator-combine-pipeline-5.3.0.tgz#a2a926073dace06ddbf9824020fc78b961fd6286"
   integrity sha512-I3OzVq2HlFOREEUBm5r4Hs8J1gDGyL4Ms45e2gJfEfuQuMKIIdCeUkdLrqHhqA1xgryybFV2PZ2bD7L6V2/xVw==
@@ -4030,14 +3819,7 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-combine-union@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-4.0.2.tgz#f2b3b4b9da6b90934a890f2acacc0ebf2061607e"
-  integrity sha512-upb0h6pWgithAvTH9iTa8lVQkUaI4a/+f7oh/F3suBULOA3mlACLp3eQU8w9tUnnKYujI7+sW9lH9uRkF34o7A==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-
-"@comunica/mediator-combine-union@^5.3.0":
+"@comunica/mediator-combine-union@^5.0.0", "@comunica/mediator-combine-union@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-combine-union/-/mediator-combine-union-5.3.0.tgz#f4effdd6840914fc0ad6d4940c45dced4e6a6043"
   integrity sha512-us4Ficcn9dMfeMAWPYaM386hwsWzBjYF2VClSkCn3hQW8G702HOs384pxFA5CDaqUUpn2HZZdokM72S8JTMFCg==
@@ -4062,14 +3844,7 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-number@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-4.0.2.tgz#c3e7b8210f00c4bd83435e09cfafa9f3dfe47829"
-  integrity sha512-m4aLqDtxvM8bZjFlgkoStYczyLnZ+bobx7LcVnj0j3Kws50UMU+k44brToi20i55oYcxi4T3zm4fjLrM6nBRcQ==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-
-"@comunica/mediator-number@^5.3.0":
+"@comunica/mediator-number@^5.0.0", "@comunica/mediator-number@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-number/-/mediator-number-5.3.0.tgz#5a313ff91e39f97a342c8b967024a638b99816fa"
   integrity sha512-Mb21LNiMZfjN4fF9st7eBpupX+AdrPLSrzJ8jquv5N5jK3ss8ctAPU6Kqs8c6DLkTmdfGIqUt9lQMQ7fodgj1A==
@@ -4083,14 +3858,7 @@
   dependencies:
     "@comunica/core" "^2.10.0"
 
-"@comunica/mediator-race@^4.0.1":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-4.0.2.tgz#89b0992037b7bb3eb7caa5c5de3b583670613129"
-  integrity sha512-gzPRxWZaWwBEzfKPy3Qhuk1oDLd4hE+AvAbA4rE7xICmF4sgU/wSHiBM809vhi6HE818d509xFwEB9R/gXDNNQ==
-  dependencies:
-    "@comunica/core" "^4.0.2"
-
-"@comunica/mediator-race@^5.3.0":
+"@comunica/mediator-race@^5.0.0", "@comunica/mediator-race@^5.3.0":
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/@comunica/mediator-race/-/mediator-race-5.3.0.tgz#8c2ebac45716361bdaaf9ae38878dbd392c19cdf"
   integrity sha512-m66N9pMJ5FHS4Pt8arLyIS85cfDsXmhAcUxUVbxQw1+hAfBoQKRmWfZdTqdW55d9xeMxZysGFV1w3k5aar4SKA==
@@ -4118,13 +3886,6 @@
   integrity sha512-nBz1exxrja1Tj8KSlSevG4Hw2u09tTh6gtNfVjI76i/e7muu4RUWVhi9b8PcwBNAfuUqRl+5OgOSa2X4W+6QlA==
   dependencies:
     "@comunica/core" "^2.10.0"
-
-"@comunica/mediatortype-time@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/mediatortype-time/-/mediatortype-time-4.0.2.tgz#c6ed5af78bad0c07c93aab5f800106df5772f069"
-  integrity sha512-+GhNGviCWtuXtmUUwRhC80lKjQSrrHES0X7M578wq4wJ+LbPS8QSqQwYS/hVQ0pofPaJXZwmHa+7zwE59cQwqg==
-  dependencies:
-    "@comunica/core" "^4.0.2"
 
 "@comunica/mediatortype-time@^5.3.0":
   version "5.3.0"
@@ -4428,17 +4189,6 @@
     "@types/yargs" "^17.0.24"
     asynciterator "^3.8.1"
     sparqlalgebrajs "^4.2.0"
-
-"@comunica/types@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@comunica/types/-/types-4.0.2.tgz#7ebe746ffcbb166ef0f9f95c7f7b5f04747ef6fc"
-  integrity sha512-Gxx755NlVww5BpdREYFYUYNazCazQsk2NMCuRfIEyHmCtU2eCc6RJk6YqKKLRCjaHcWIfBVtbbsbySzG8leS0g==
-  dependencies:
-    "@rdfjs/types" "*"
-    "@types/yargs" "^17.0.24"
-    asynciterator "^3.9.0"
-    lru-cache "^10.0.1"
-    sparqlalgebrajs "^4.3.8"
 
 "@comunica/types@^5.3.0":
   version "5.3.0"
@@ -8111,7 +7861,7 @@ ignore@^5.0.5, ignore@^5.2.0, ignore@^5.2.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.2.tgz#3cd40e729f3643fd87cb04e50bf0eb722bc596f5"
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
-immutable@^4.1.0, immutable@^4.3.7:
+immutable@^4.1.0:
   version "4.3.7"
   resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.7.tgz#c70145fc90d89fb02021e65c84eb0226e4e5a381"
   integrity sha512-1hqclzwYwjRDFLjcFxOM5AYkkG0rpFPpr1RLPMEuGczoS7YA8gLhy8SWXYRAA/XwfEHpfo3cw5JGioS32fnMRw==
@@ -9058,22 +8808,6 @@ jsonld-streaming-parser@^3.0.1:
     rdf-data-factory "^1.1.0"
     readable-stream "^4.0.0"
 
-jsonld-streaming-parser@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/jsonld-streaming-parser/-/jsonld-streaming-parser-4.0.1.tgz#41212df7ef21df1f970d09ef989261fbb566194b"
-  integrity sha512-6M4y9YGgADk3nXJebbRrxEdMVBJ9bnz+peAvjTXUievopqaE8sg/qml/I6Sp1ln7rpOKffsNZWSre6B7N76szw==
-  dependencies:
-    "@bergos/jsonparse" "^1.4.0"
-    "@rdfjs/types" "*"
-    "@types/http-link-header" "^1.0.1"
-    "@types/readable-stream" "^4.0.0"
-    buffer "^6.0.3"
-    canonicalize "^1.0.1"
-    http-link-header "^1.0.2"
-    jsonld-context-parser "^3.0.0"
-    rdf-data-factory "^1.1.0"
-    readable-stream "^4.0.0"
-
 jsonld-streaming-parser@^5.0.0:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/jsonld-streaming-parser/-/jsonld-streaming-parser-5.0.1.tgz#b61f0eea4d1311ec903ee0c48a5d73cf45cf673d"
@@ -9239,7 +8973,7 @@ loose-envify@^1.4.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
-lru-cache@^10.0.1, lru-cache@^10.2.0:
+lru-cache@^10.2.0:
   version "10.4.3"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-10.4.3.tgz#410fc8a17b70e598013df257c2446b7f3383f119"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
@@ -10126,36 +9860,36 @@ rdf-parse@^2.0.0:
     readable-stream "^4.3.0"
     stream-to-string "^1.2.0"
 
-rdf-parse@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-4.0.0.tgz#5caedafa088a9e2d5263b865e0a5f631ce359cab"
-  integrity sha512-lNVuUKPVAdX9lJYYrJFhdQHFulYjk95BYvuNsE+eUs/M93sdsovH/Ga8bTAxagmpsoQ4LzMPa2YqeHX8ysltOA==
+rdf-parse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/rdf-parse/-/rdf-parse-5.0.0.tgz#ab474693fd4d8378c357479435df79cbb4afbdeb"
+  integrity sha512-q2UO1DCP9IbcX1Yvv+FJCd6c2PmFRpWVYuG8nuTPhOqcS2QYvP0cs6UOaHr0Lhoh7jbrvVbPx3Pb4mdwBrF8bQ==
   dependencies:
-    "@comunica/actor-http-fetch" "^4.0.1"
-    "@comunica/actor-http-proxy" "^4.0.1"
-    "@comunica/actor-rdf-parse-html" "^4.0.1"
-    "@comunica/actor-rdf-parse-html-microdata" "^4.0.1"
-    "@comunica/actor-rdf-parse-html-rdfa" "^4.0.1"
-    "@comunica/actor-rdf-parse-html-script" "^4.0.1"
-    "@comunica/actor-rdf-parse-jsonld" "^4.0.1"
-    "@comunica/actor-rdf-parse-n3" "^4.0.1"
-    "@comunica/actor-rdf-parse-rdfxml" "^4.0.1"
-    "@comunica/actor-rdf-parse-shaclc" "^4.0.1"
-    "@comunica/actor-rdf-parse-xml-rdfa" "^4.0.1"
-    "@comunica/bus-http" "^4.0.1"
-    "@comunica/bus-init" "^4.0.1"
-    "@comunica/bus-rdf-parse" "^4.0.1"
-    "@comunica/bus-rdf-parse-html" "^4.0.1"
-    "@comunica/config-query-sparql" "^4.0.1"
-    "@comunica/context-entries" "^4.0.1"
-    "@comunica/core" "^4.0.1"
-    "@comunica/mediator-combine-pipeline" "^4.0.1"
-    "@comunica/mediator-combine-union" "^4.0.1"
-    "@comunica/mediator-number" "^4.0.1"
-    "@comunica/mediator-race" "^4.0.1"
+    "@comunica/actor-http-fetch" "^5.0.0"
+    "@comunica/actor-http-proxy" "^5.0.0"
+    "@comunica/actor-rdf-parse-html" "^5.0.0"
+    "@comunica/actor-rdf-parse-html-microdata" "^5.0.0"
+    "@comunica/actor-rdf-parse-html-rdfa" "^5.0.0"
+    "@comunica/actor-rdf-parse-html-script" "^5.0.0"
+    "@comunica/actor-rdf-parse-jsonld" "^5.0.0"
+    "@comunica/actor-rdf-parse-n3" "^5.0.0"
+    "@comunica/actor-rdf-parse-rdfxml" "^5.0.0"
+    "@comunica/actor-rdf-parse-shaclc" "^5.0.0"
+    "@comunica/actor-rdf-parse-xml-rdfa" "^5.0.0"
+    "@comunica/bus-http" "^5.0.0"
+    "@comunica/bus-init" "^5.0.0"
+    "@comunica/bus-rdf-parse" "^5.0.0"
+    "@comunica/bus-rdf-parse-html" "^5.0.0"
+    "@comunica/config-query-sparql" "^5.0.0"
+    "@comunica/context-entries" "^5.0.0"
+    "@comunica/core" "^5.0.0"
+    "@comunica/mediator-combine-pipeline" "^5.0.0"
+    "@comunica/mediator-combine-union" "^5.0.0"
+    "@comunica/mediator-number" "^5.0.0"
+    "@comunica/mediator-race" "^5.0.0"
     "@rdfjs/types" "*"
-    rdf-data-factory "^1.1.2"
-    readable-stream "^4.5.2"
+    rdf-data-factory "^2.0.2"
+    readable-stream "^4.7.0"
     stream-to-string "^1.2.1"
 
 rdf-quad@^1.5.0:
@@ -10771,7 +10505,7 @@ spark-md5@^3.0.1:
   resolved "https://registry.yarnpkg.com/spark-md5/-/spark-md5-3.0.2.tgz#7952c4a30784347abcee73268e473b9c0167e3fc"
   integrity sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==
 
-sparqlalgebrajs@^4.2.0, sparqlalgebrajs@^4.3.8:
+sparqlalgebrajs@^4.2.0:
   version "4.3.8"
   resolved "https://registry.yarnpkg.com/sparqlalgebrajs/-/sparqlalgebrajs-4.3.8.tgz#2b339120fc3e4d7cc952c113ee6f1ab8e0d3b7a5"
   integrity sha512-Xo1/5icRtVk2N38BrY9NXN8N/ZPjULlns7sDHv0nlcGOsOediBLWVy8LmV+Q90RHvb3atZZbrFy3VqrM4iXciA==


### PR DESCRIPTION
## Summary
This pull request updates several key dependencies to their latest major versions to improve compatibility and access new features.

## Key Changes
- Added `jsonld-context-parser` (^3.1.0) as a new dependency for JSON-LD context parsing
- Updated `@comunica/actor-http-proxy` from ^4.0.2 to ^5.0.0
- Updated `@comunica/query-sparql` from ^4.0.2 to ^5.0.0
- Updated `rdf-parse` from ^4.0.0 to ^5.0.0

## Notes
These are major version updates that may include breaking changes. The lockfile has been updated to reflect the transitive dependency resolution for these new versions.

https://claude.ai/code/session_013b7L3puEFF1vbtETRwXnq6